### PR TITLE
fix: 댓글 조회

### DIFF
--- a/src/main/java/project/votebackend/dto/CommentResponse.java
+++ b/src/main/java/project/votebackend/dto/CommentResponse.java
@@ -1,12 +1,16 @@
 package project.votebackend.dto;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Builder;
 import lombok.Data;
 import project.votebackend.domain.Comment;
 
 import java.time.LocalDateTime;
+import java.util.List;
+import java.util.stream.Collectors;
 
 @Data
+@Builder
 public class CommentResponse {
     private Long id;
     private Long userId;
@@ -19,21 +23,44 @@ public class CommentResponse {
 
     @JsonProperty("isLiked")
     private boolean isLiked;
+    private List<CommentResponse> replies;
 
     public static CommentResponse fromEntity(Comment comment, Long currentUserId) {
         boolean isLiked = comment.getCommentLikes().stream()
                 .anyMatch(like -> like.getUser().getUserId().equals(currentUserId));
 
-        CommentResponse dto = new CommentResponse();
-        dto.id = comment.getCommentId();
-        dto.userId = comment.getUser().getUserId();
-        dto.username = comment.getUser().getUsername();
-        dto.content = comment.getContent();
-        dto.createdAt = comment.getCreatedAt();
-        dto.profileImage = comment.getUser().getProfileImage();
-        dto.likeCount = comment.getLikeCount();
-        dto.parentId = comment.getParent() != null ? comment.getParent().getCommentId() : null;
-        dto.isLiked = isLiked;
-        return dto;
+        return CommentResponse.builder()
+                .id(comment.getCommentId())
+                .userId(comment.getUser().getUserId())
+                .username(comment.getUser().getUsername())
+                .content(comment.getContent())
+                .createdAt(comment.getCreatedAt())
+                .profileImage(comment.getUser().getProfileImage())
+                .likeCount(comment.getLikeCount())
+                .parentId(comment.getParent() != null ? comment.getParent().getCommentId() : null)
+                .isLiked(isLiked)
+                .replies(null)
+                .build();
+    }
+
+    // 대댓글 포함 버전
+    public static CommentResponse fromEntityWithReplies(Comment parent, List<Comment> replies, Long currentUserId) {
+        boolean isLiked = parent.getCommentLikes().stream()
+                .anyMatch(like -> like.getUser().getUserId().equals(currentUserId));
+
+        return CommentResponse.builder()
+                .id(parent.getCommentId())
+                .userId(parent.getUser().getUserId())
+                .username(parent.getUser().getUsername())
+                .content(parent.getContent())
+                .createdAt(parent.getCreatedAt())
+                .profileImage(parent.getUser().getProfileImage())
+                .likeCount(parent.getLikeCount())
+                .parentId(null)
+                .isLiked(isLiked)
+                .replies(replies.stream()
+                        .map(reply -> fromEntity(reply, currentUserId))
+                        .collect(Collectors.toList()))
+                .build();
     }
 }

--- a/src/main/java/project/votebackend/dto/LoadVoteDto.java
+++ b/src/main/java/project/votebackend/dto/LoadVoteDto.java
@@ -46,7 +46,11 @@ public class LoadVoteDto {
 
     //Entity -> Dto 변환 후 반환
     public static LoadVoteDto fromEntity(Vote vote, Long currentUserId, VoteSelectRepository voteSelectRepository) {
-        int commentCount = vote.getComments() != null ? vote.getComments().size() : 0;
+        int commentCount = vote.getComments() != null
+                ? (int) vote.getComments().stream()
+                .filter(c -> c.getParent() == null) // 부모 댓글만 필터링
+                .count()
+                : 0;
         int likeCount = (int) vote.getReactions().stream()
                 .filter(r -> r.getReaction() == ReactionType.LIKE)
                 .distinct()

--- a/src/main/java/project/votebackend/repository/CommentRepository.java
+++ b/src/main/java/project/votebackend/repository/CommentRepository.java
@@ -6,7 +6,14 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 import project.votebackend.domain.Comment;
 
+import java.util.List;
+
 @Repository
 public interface CommentRepository extends JpaRepository<Comment, Long> {
-    Page<Comment> findByVote_VoteId(Long voteId, Pageable pageable);
+    //부모 댓글
+    Page<Comment> findByVote_VoteIdAndParentIsNull(Long voteId, Pageable pageable);
+
+    //자식 댓글
+    List<Comment> findByParent_CommentIdOrderByCreatedAtAsc(Long parentId);
+
 }


### PR DESCRIPTION
기존 댓글과 답글을 한번에 조회하여, ux를 고려했을때 자연스러운 댓글 조회가 안됐음. 따라서 댓글과 답글을 따로 분리한 데이터를 보내줌