### PR TITLE
refactor: 마이페이지 및 유저페이지에 VoteStatisticsUtil 적용하여 중복 제거

### DIFF
--- a/src/main/java/project/votebackend/service/StorageService.java
+++ b/src/main/java/project/votebackend/service/StorageService.java
@@ -2,35 +2,51 @@ package project.votebackend.service;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import project.votebackend.domain.Vote;
 import project.votebackend.dto.LoadVoteDto;
+import project.votebackend.repository.CommentRepository;
+import project.votebackend.repository.ReactionRepository;
 import project.votebackend.repository.VoteRepository;
 import project.votebackend.repository.VoteSelectRepository;
+import project.votebackend.util.VoteStatisticsUtil;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
 public class StorageService {
 
     private final VoteRepository voteRepository;
-    private final VoteSelectRepository voteSelectRepository;
+    private final VoteStatisticsUtil voteStatisticsUtil;
+
 
     //내가 투표한 게시물
     public Page<LoadVoteDto> getVotedPosts(Long userId, Pageable pageable) {
         Page<Vote> votes = voteRepository.findVotedByUserId(userId, pageable);
-        return votes.map(v -> LoadVoteDto.fromEntity(v, userId, voteSelectRepository));
+        List<Long> voteIds = votes.getContent().stream().map(Vote::getVoteId).toList();
+        Map<String, Object> stats = voteStatisticsUtil.collectVoteStatistics(userId, voteIds);
+        return voteStatisticsUtil.getLoadVoteDtos(userId, votes, stats, pageable);
     }
 
     //좋아요한 게시물
     public Page<LoadVoteDto> getLikedPosts(Long userId, Pageable pageable) {
         Page<Vote> votes = voteRepository.findLikedVotes(userId, pageable);
-        return votes.map(v -> LoadVoteDto.fromEntity(v, userId, voteSelectRepository));
+        List<Long> voteIds = votes.getContent().stream().map(Vote::getVoteId).toList();
+        Map<String, Object> stats = voteStatisticsUtil.collectVoteStatistics(userId, voteIds);
+        return voteStatisticsUtil.getLoadVoteDtos(userId, votes, stats, pageable);
     }
 
     //북마크한 게시물
     public Page<LoadVoteDto> getBookmarkedPosts(Long userId, Pageable pageable) {
         Page<Vote> votes = voteRepository.findBookmarkedVotes(userId, pageable);
-        return votes.map(v -> LoadVoteDto.fromEntity(v, userId, voteSelectRepository));
+        List<Long> voteIds = votes.getContent().stream().map(Vote::getVoteId).toList();
+        Map<String, Object> stats = voteStatisticsUtil.collectVoteStatistics(userId, voteIds);
+        return voteStatisticsUtil.getLoadVoteDtos(userId, votes, stats, pageable);
     }
 }

--- a/src/main/java/project/votebackend/util/VoteStatisticsUtil.java
+++ b/src/main/java/project/votebackend/util/VoteStatisticsUtil.java
@@ -1,0 +1,88 @@
+package project.votebackend.util;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Component;
+import project.votebackend.domain.Vote;
+import project.votebackend.dto.LoadVoteDto;
+import project.votebackend.repository.CommentRepository;
+import project.votebackend.repository.ReactionRepository;
+import project.votebackend.repository.VoteSelectRepository;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+@Component
+@RequiredArgsConstructor
+public class VoteStatisticsUtil {
+
+    private final VoteSelectRepository voteSelectRepository;
+    private final CommentRepository commentRepository;
+    private final ReactionRepository reactionRepository;
+
+    public Map<String, Object> collectVoteStatistics(Long userId, List<Long> voteIds) {
+        Map<String, Object> result = new HashMap<>();
+
+        Map<Long, Integer> optionVoteCountMap = voteSelectRepository.findOptionVoteCounts(voteIds).stream()
+                .collect(Collectors.toMap(
+                        row -> ((Number) row[0]).longValue(),
+                        row -> ((Number) row[1]).intValue()
+                ));
+
+        Map<Long, Integer> commentCountMap = commentRepository.countParentCommentsByVoteIds(voteIds).stream()
+                .collect(Collectors.toMap(
+                        row -> ((Number) row[0]).longValue(),
+                        row -> ((Number) row[1]).intValue()
+                ));
+
+        List<Object[]> reactionRows = reactionRepository.findReactionsByVoteIds(voteIds);
+
+        Map<Long, Integer> likeCountMap = new HashMap<>();
+        Map<Long, Boolean> isLikedMap = new HashMap<>();
+        Map<Long, Boolean> isBookmarkedMap = new HashMap<>();
+
+        for (Object[] row : reactionRows) {
+            Long voteId = (Long) row[0];
+            String reaction = row[1].toString();
+            Long reactedUserId = (Long) row[2];
+
+            if (reaction.equals("LIKE")) {
+                likeCountMap.put(voteId, likeCountMap.getOrDefault(voteId, 0) + 1);
+                if (reactedUserId.equals(userId)) {
+                    isLikedMap.put(voteId, true);
+                }
+            }
+
+            if (reaction.equals("BOOKMARK") && reactedUserId.equals(userId)) {
+                isBookmarkedMap.put(voteId, true);
+            }
+        }
+
+        result.put("optionVoteCountMap", optionVoteCountMap);
+        result.put("commentCountMap", commentCountMap);
+        result.put("likeCountMap", likeCountMap);
+        result.put("isLikedMap", isLikedMap);
+        result.put("isBookmarkedMap", isBookmarkedMap);
+
+        return result;
+    }
+
+    public Page<LoadVoteDto> getLoadVoteDtos(Long userId, Page<Vote> votes, Map<String, Object> stats, Pageable pageable) {
+        List<LoadVoteDto> dtos = votes.getContent().stream()
+                .map(v -> LoadVoteDto.fromEntityWithAllMaps(
+                        v, userId, voteSelectRepository,
+                        (Map<Long, Integer>) stats.get("optionVoteCountMap"),
+                        (Map<Long, Integer>) stats.get("commentCountMap"),
+                        (Map<Long, Integer>) stats.get("likeCountMap"),
+                        (Map<Long, Boolean>) stats.get("isLikedMap"),
+                        (Map<Long, Boolean>) stats.get("isBookmarkedMap")
+                ))
+                .toList();
+
+        return new PageImpl<>(dtos, pageable, votes.getTotalElements());
+    }
+}


### PR DESCRIPTION
### 기존 문제
getMyPage()와 getUserPage()에서 각 투표에 대해 LoadVoteDto.fromEntity(...)만 사용해 좋아요, 댓글 수, 북마크 등 통계 정보가 누락되어 있었음

### 리팩토링 핵심
→ 기존의 VoteStatisticsUtil.collectVoteStatistics()와 getLoadVoteDtos() 메서드를 활용해
투표 통계 포함된 DTO 리스트 반환하도록 개선

### 장점
통계 정보 일관되게 포함됨 (댓글 수, 좋아요 수, 선택 여부 등)
코드 중복 제거 및 유지보수성 향상