### PR TITLE
fix: scheduler 시간 변경

### DIFF
--- a/src/main/java/project/votebackend/scheduler/VoteStatScheduler.java
+++ b/src/main/java/project/votebackend/scheduler/VoteStatScheduler.java
@@ -20,7 +20,7 @@ public class VoteStatScheduler {
     }
 
     // 1시간 단위 관심 급등 통계 갱신
-    @Scheduled(cron = "0 0 * * * *") // 매 정각
+    @Scheduled(cron = "0 2 * * * *") // 매 정각
     public void runHourlyTrendingStatUpdate() {
         log.info("[스케줄] 1시간 단위 관심 급등 통계 시작");
         voteSchedulingService.generateHourlyStats();


### PR DESCRIPTION
현재 스케줄러는 6시간, 1시간 단위로 작동

만약 두 작업이 겹쳤을때의 CPU 부하, 커넥션 풀 고갈 등의 문제 발생 우려

- 1시간 단위의 작업을 정시 2분에 실행하여 여유를 주는 것이 좋을 것 같다고 판단