### PR TITLE
feat: [042-email-auth] 이메일 전송 및 검증

### DIFF
--- a/src/main/java/project/votebackend/config/MailConfig.java
+++ b/src/main/java/project/votebackend/config/MailConfig.java
@@ -1,0 +1,43 @@
+package project.votebackend.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.mail.javamail.JavaMailSenderImpl;
+
+import java.util.Properties;
+
+@Configuration
+public class MailConfig {
+
+    @Value("${spring.mail.host}")
+    private String host;
+
+    @Value("${spring.mail.port}")
+    private int port;
+
+    @Value("${spring.mail.username}")
+    private String username;
+
+    @Value("${spring.mail.password}")
+    private String password;
+
+    @Bean
+    public JavaMailSender javaMailSender() {
+        JavaMailSenderImpl mailSender = new JavaMailSenderImpl();
+        mailSender.setHost(host);
+        mailSender.setPort(port);
+        mailSender.setUsername(username);
+        mailSender.setPassword(password);
+
+        Properties props = mailSender.getJavaMailProperties();
+        props.put("mail.smtp.auth", true);
+        props.put("mail.smtp.starttls.enable", true);
+        props.put("mail.smtp.ssl.protocols", "TLSv1.2");
+        props.put("mail.debug", true); // 로그 확인용
+
+        return mailSender;
+    }
+}
+

--- a/src/main/java/project/votebackend/config/SecurityConfig.java
+++ b/src/main/java/project/votebackend/config/SecurityConfig.java
@@ -33,7 +33,7 @@ public class SecurityConfig {
                 // 요청에 대한 권한 설정
                 .authorizeHttpRequests(auth -> auth
                         // 로그인, 회원가입, 공유 등의 인증 없이 접근 가능한 엔드포인트
-                        .requestMatchers("/location/verify","/auth/**", "/image/upload", "/share/vote/**").permitAll()
+                        .requestMatchers("/location/verify","/auth/**", "/image/upload", "/share/vote/**", "/email/**").permitAll()
 
                         // 아래 엔드포인트는 인증된 사용자만 접근 가능
                         .requestMatchers(

--- a/src/main/java/project/votebackend/controller/email/EmailController.java
+++ b/src/main/java/project/votebackend/controller/email/EmailController.java
@@ -1,0 +1,32 @@
+package project.votebackend.controller.email;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import project.votebackend.dto.email.EmailRequest;
+import project.votebackend.dto.email.EmailVerifyRequest;
+import project.votebackend.service.email.EmailService;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/email")
+public class EmailController {
+
+    private final EmailService emailService;
+
+    // 인증 코드 발송
+    @PostMapping("/send")
+    public ResponseEntity<String> sendCode(@RequestBody EmailRequest request) {
+        emailService.sendVerificationCode(request.getEmail());
+        return ResponseEntity.ok("인증 코드가 발송되었습니다.");
+    }
+
+    // 인증 코드 검증
+    @PostMapping("/verify")
+    public ResponseEntity<String> verifyCode(@RequestBody EmailVerifyRequest request) {
+        boolean result = emailService.verifyCode(request.getEmail(), request.getCode());
+        return result
+                ? ResponseEntity.ok("이메일 인증 성공")
+                : ResponseEntity.badRequest().body("인증 실패 또는 만료된 코드");
+    }
+}

--- a/src/main/java/project/votebackend/domain/auth/VerificationCode.java
+++ b/src/main/java/project/votebackend/domain/auth/VerificationCode.java
@@ -1,0 +1,24 @@
+package project.votebackend.domain.auth;
+
+import jakarta.persistence.*;
+import lombok.*;
+import project.votebackend.domain.BaseEntity;
+
+@Entity
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class VerificationCode extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private String email;
+
+    @Column(nullable = false)
+    private String code;
+}

--- a/src/main/java/project/votebackend/dto/email/EmailRequest.java
+++ b/src/main/java/project/votebackend/dto/email/EmailRequest.java
@@ -1,0 +1,8 @@
+package project.votebackend.dto.email;
+
+import lombok.Data;
+
+@Data
+public class EmailRequest {
+    private String email;
+}

--- a/src/main/java/project/votebackend/dto/email/EmailVerifyRequest.java
+++ b/src/main/java/project/votebackend/dto/email/EmailVerifyRequest.java
@@ -1,0 +1,9 @@
+package project.votebackend.dto.email;
+
+import lombok.Data;
+
+@Data
+public class EmailVerifyRequest {
+    private String email;
+    private String code;
+}

--- a/src/main/java/project/votebackend/repository/auth/VerificationCodeRepository.java
+++ b/src/main/java/project/votebackend/repository/auth/VerificationCodeRepository.java
@@ -1,0 +1,12 @@
+package project.votebackend.repository.auth;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+import project.votebackend.domain.auth.VerificationCode;
+
+import java.util.Optional;
+
+@Repository
+public interface VerificationCodeRepository extends JpaRepository<VerificationCode, Long> {
+    Optional<VerificationCode> findTopByEmailOrderByCreatedAtDesc(String email);
+}

--- a/src/main/java/project/votebackend/service/email/EmailService.java
+++ b/src/main/java/project/votebackend/service/email/EmailService.java
@@ -1,0 +1,57 @@
+package project.votebackend.service.email;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.mail.SimpleMailMessage;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.stereotype.Service;
+import project.votebackend.domain.auth.VerificationCode;
+import project.votebackend.exception.AuthException;
+import project.votebackend.repository.auth.VerificationCodeRepository;
+import project.votebackend.type.ErrorCode;
+
+import java.time.Duration;
+import java.time.LocalDateTime;
+
+@Service
+@RequiredArgsConstructor
+public class EmailService {
+
+    private final JavaMailSender mailSender;
+    private final VerificationCodeRepository verificationCodeRepository;
+
+    // 인증 코드 전송
+    public void sendVerificationCode(String email) {
+        String code = createRandomCode();
+
+        // DB에 저장 (이메일, 코드, 생성 시간)
+        VerificationCode entity = VerificationCode.builder()
+                .email(email)
+                .code(code)
+                .build();
+        verificationCodeRepository.save(entity);
+
+        // 이메일 발송
+        SimpleMailMessage message = new SimpleMailMessage();
+        message.setTo(email);
+        message.setSubject("이메일 인증 코드");
+        message.setText("인증 코드는: " + code);
+        mailSender.send(message);
+    }
+
+    private String createRandomCode() {
+        return String.valueOf((int)((Math.random() * 900000) + 100000)); // 6자리 숫자
+    }
+
+    // 인증 코드 검증
+    public boolean verifyCode(String email, String code) {
+        VerificationCode vc = verificationCodeRepository.findTopByEmailOrderByCreatedAtDesc(email)
+                .orElseThrow(() -> new AuthException(ErrorCode.CODE_NOT_MATCHED));
+
+        // 유효 시간: 5분
+        if (Duration.between(vc.getCreatedAt(), LocalDateTime.now()).toMinutes() > 5) {
+            return false;
+        }
+
+        return vc.getCode().equals(code);
+    }
+}

--- a/src/main/java/project/votebackend/type/ErrorCode.java
+++ b/src/main/java/project/votebackend/type/ErrorCode.java
@@ -29,7 +29,10 @@ public enum ErrorCode {
     COMMENT_NOT_FOUNT(HttpStatus.NOT_FOUND, "존재하지 않는 댓글입니다."),
 
     //Follow
-    ALREADY_FOLLOW(HttpStatus.CONFLICT, "이미 팔로우 중입니다.");
+    ALREADY_FOLLOW(HttpStatus.CONFLICT, "이미 팔로우 중입니다."),
+
+    //Mail
+    CODE_NOT_MATCHED(HttpStatus.CONFLICT, "코드가 일치하지 않습니다.");
 
 
     private final HttpStatus httpStatus;


### PR DESCRIPTION
📌 관련 이슈
- [042-email-auth]

🔍 작업 내용
- 이메일 인증 코드 발송 API  구현
- 인증 코드 검증 API 구현
- 인증 코드 유효시간 5분 설정
- 인증 이력 DB 저장 
- JavaMailSender를 통한 이메일 발송 연동
