### PR TITLE
feat: [040-edit-profile] 프로필 수정

### DIFF
--- a/src/main/java/project/votebackend/controller/auth/AuthController.java
+++ b/src/main/java/project/votebackend/controller/auth/AuthController.java
@@ -3,11 +3,14 @@ package project.votebackend.controller.auth;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.validation.BindingResult;
 import org.springframework.web.bind.annotation.*;
 import project.votebackend.domain.user.User;
 import project.votebackend.dto.login.LoginRequest;
 import project.votebackend.dto.signup.UserSignupDto;
+import project.votebackend.dto.user.UserUpdateDto;
+import project.votebackend.security.CustumUserDetails;
 import project.votebackend.service.auth.AuthService;
 
 import java.util.Map;

--- a/src/main/java/project/votebackend/controller/user/UserController.java
+++ b/src/main/java/project/votebackend/controller/user/UserController.java
@@ -1,5 +1,6 @@
 package project.votebackend.controller.user;
 
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
@@ -7,7 +8,9 @@ import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
+import project.votebackend.domain.user.User;
 import project.votebackend.dto.user.UserPageDto;
+import project.votebackend.dto.user.UserUpdateDto;
 import project.votebackend.security.CustumUserDetails;
 import project.votebackend.service.user.UserService;
 
@@ -37,5 +40,15 @@ public class UserController {
     ) {
         UserPageDto userPage = userService.getUserPage(userId, PageRequest.of(page, size));
         return ResponseEntity.ok(userPage);
+    }
+
+    //회원정보 수정
+    @PutMapping("/user/update")
+    public ResponseEntity<User> updateUserInfo(
+            @AuthenticationPrincipal CustumUserDetails userDetails,
+            @RequestBody @Valid UserUpdateDto dto
+    ) {
+        User updatedUser = userService.updateUser(userDetails.getId(), dto);
+        return ResponseEntity.ok(updatedUser);
     }
 }

--- a/src/main/java/project/votebackend/dto/user/UserUpdateDto.java
+++ b/src/main/java/project/votebackend/dto/user/UserUpdateDto.java
@@ -1,0 +1,16 @@
+package project.votebackend.dto.user;
+
+import jakarta.validation.constraints.Size;
+import lombok.Data;
+
+import java.util.List;
+
+@Data
+public class UserUpdateDto {
+    private String name;
+    private String profileImage; // 새 프로필 이미지 URL
+    private List<Long> interestCategory;
+
+    @Size(max = 200, message = "자기소개는 200자 이내여야 합니다.")
+    private String introduction;
+}

--- a/src/main/java/project/votebackend/repository/user/UserInterestRepository.java
+++ b/src/main/java/project/votebackend/repository/user/UserInterestRepository.java
@@ -2,8 +2,10 @@ package project.votebackend.repository.user;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
+import project.votebackend.domain.user.User;
 import project.votebackend.domain.user.UserInterest;
 
 @Repository
 public interface UserInterestRepository extends JpaRepository<UserInterest, Long> {
+    void deleteByUser(User user);
 }


### PR DESCRIPTION
📌 관련 이슈
- [040-edit-profile]

🔍 작업 내용
1. 프로필 수정 기능 구현 (닉네임, 프로필이미지, 관심카테고리, 자기소개 수정가능)
2. 프로필 이미지 변경 시 기존 이미지 삭제 로직 추가
3. 사용자가 새 프로필 이미지를 업로드할 경우, 기존 이미지가 default.png가 아니고 서로 다를 경우 이전 이미지를 S3에서 삭제하도록 처리
