### PR TITLE
fix: [040-edit-profile] 프로필 수정시 dto 반환

### DIFF
--- a/src/main/java/project/votebackend/controller/user/UserController.java
+++ b/src/main/java/project/votebackend/controller/user/UserController.java
@@ -10,6 +10,7 @@ import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 import project.votebackend.domain.user.User;
 import project.votebackend.dto.user.UserPageDto;
+import project.votebackend.dto.user.UserResponseDto;
 import project.votebackend.dto.user.UserUpdateDto;
 import project.votebackend.security.CustumUserDetails;
 import project.votebackend.service.user.UserService;
@@ -44,11 +45,11 @@ public class UserController {
 
     //회원정보 수정
     @PutMapping("/user/update")
-    public ResponseEntity<User> updateUserInfo(
+    public ResponseEntity<UserResponseDto> updateUserInfo(
             @AuthenticationPrincipal CustumUserDetails userDetails,
             @RequestBody @Valid UserUpdateDto dto
     ) {
-        User updatedUser = userService.updateUser(userDetails.getId(), dto);
+        UserResponseDto updatedUser = userService.updateUser(userDetails.getId(), dto);
         return ResponseEntity.ok(updatedUser);
     }
 }

--- a/src/main/java/project/votebackend/dto/user/UserResponseDto.java
+++ b/src/main/java/project/votebackend/dto/user/UserResponseDto.java
@@ -1,0 +1,27 @@
+package project.votebackend.dto.user;
+
+import lombok.Builder;
+import lombok.Getter;
+import project.votebackend.domain.user.User;
+
+import java.util.List;
+
+@Getter
+@Builder
+public class UserResponseDto {
+    private Long userId;
+    private String name;
+    private String profileImage;
+    private String introduction;
+    private List<String> interestCategories;
+
+    public static UserResponseDto fromEntity(User user, List<String> interestCategories) {
+        return UserResponseDto.builder()
+                .userId(user.getUserId())
+                .name(user.getName())
+                .profileImage(user.getProfileImage())
+                .introduction(user.getIntroduction())
+                .interestCategories(interestCategories)
+                .build();
+    }
+}

--- a/src/main/java/project/votebackend/repository/user/UserInterestRepository.java
+++ b/src/main/java/project/votebackend/repository/user/UserInterestRepository.java
@@ -5,7 +5,12 @@ import org.springframework.stereotype.Repository;
 import project.votebackend.domain.user.User;
 import project.votebackend.domain.user.UserInterest;
 
+import java.util.Collection;
+import java.util.List;
+
 @Repository
 public interface UserInterestRepository extends JpaRepository<UserInterest, Long> {
     void deleteByUser(User user);
+
+    List<UserInterest> findByUser(User user);
 }


### PR DESCRIPTION
📌 관련 이슈
- [040-edit-profile] 회원정보 수정 시 DTO 반환

🔍 작업 내용
- 회원정보 수정 API 리턴 타입을 UserResponseDto로 변경
- 엔티티 직접 반환 대신 DTO를 사용해 보안성과 안정성 강화

