### PR TITLE
refactor: [051-refactor] OneToMany 최적화

### DIFF
--- a/src/main/java/project/votebackend/domain/comment/Comment.java
+++ b/src/main/java/project/votebackend/domain/comment/Comment.java
@@ -2,6 +2,7 @@ package project.votebackend.domain.comment;
 
 import jakarta.persistence.*;
 import lombok.*;
+import org.hibernate.annotations.BatchSize;
 import project.votebackend.domain.BaseEntity;
 import project.votebackend.domain.user.User;
 import project.votebackend.domain.vote.Vote;
@@ -37,9 +38,11 @@ public class Comment extends BaseEntity {
 
     private int likeCount = 0;
 
-    @OneToMany(mappedBy = "parent", cascade = CascadeType.ALL, orphanRemoval = true)
+    @OneToMany(mappedBy = "parent", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.LAZY)
+    @BatchSize(size = 50)
     private List<Comment> children = new ArrayList<>();
 
-    @OneToMany(mappedBy = "comment", cascade = CascadeType.ALL, orphanRemoval = true)
+    @OneToMany(mappedBy = "comment", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.LAZY)
+    @BatchSize(size = 50)
     private List<CommentLike> commentLikes = new ArrayList<>();
 }

--- a/src/main/java/project/votebackend/domain/vote/Vote.java
+++ b/src/main/java/project/votebackend/domain/vote/Vote.java
@@ -2,6 +2,7 @@ package project.votebackend.domain.vote;
 
 import jakarta.persistence.*;
 import lombok.*;
+import org.hibernate.annotations.BatchSize;
 import project.votebackend.domain.BaseEntity;
 import project.votebackend.domain.category.Category;
 import project.votebackend.domain.comment.Comment;
@@ -39,18 +40,23 @@ public class Vote extends BaseEntity {
     private String link;
     private LocalDateTime finishTime;
 
-    @OneToMany(mappedBy = "vote", cascade = CascadeType.ALL)
+    @OneToMany(mappedBy = "vote", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
+    @BatchSize(size = 50)
     private Set<VoteOption> options = new HashSet<>();
 
-    @OneToMany(mappedBy = "vote", cascade = CascadeType.ALL)
+    @OneToMany(mappedBy = "vote", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
+    @BatchSize(size = 50)
     private Set<VoteImage> images = new HashSet<>();
 
-    @OneToMany(mappedBy = "vote", cascade = CascadeType.ALL)
+    @OneToMany(mappedBy = "vote", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
+    @BatchSize(size = 50)
     private List<VoteSelection> selections = new ArrayList<>();
 
-    @OneToMany(mappedBy = "vote", cascade = CascadeType.ALL)
+    @OneToMany(mappedBy = "vote", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
+    @BatchSize(size = 50)
     private List<Reaction> reactions = new ArrayList<>();
 
-    @OneToMany(mappedBy = "vote", cascade = CascadeType.ALL)
+    @OneToMany(mappedBy = "vote", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
+    @BatchSize(size = 50)
     private List<Comment> comments = new ArrayList<>();
 }


### PR DESCRIPTION
### 🔍 작업 내용  
1. `Vote` 엔티티의 연관 필드에 `fetch = FetchType.LAZY` 명시  
2. `@BatchSize(size = 50)` 적용하여 N+1 문제 완화  
3. 연관 필드 접근 시 불필요한 즉시 로딩을 방지하고, 대량 조회 시 성능을 개선함  

> 🔧 적용 대상 필드:
> - `Vote.comments`  
> - `Vote.selections`  
> - `Vote.reactions`

```java
@OneToMany(mappedBy = "vote", fetch = FetchType.LAZY)
@BatchSize(size = 50)
private List<Comment> comments = new ArrayList<>();
```

### ⚙️ 성능 개선 설명

이번 PR에서는 `@OneToMany` 연관 필드에 `fetch = FetchType.LAZY`를 명시하고, `@BatchSize(size = 50)`를 적용함으로써 성능을 다음과 같이 개선하였습니다.

기존에는 `Vote` 엔티티를 조회할 때 연관된 `comments`, `selections`, `reactions` 등의 데이터가 즉시 로딩(EAGER)되면서, 조회하지 않아도 되는 데이터까지 함께 로딩되어 불필요한 쿼리와 메모리 사용이 발생했습니다.

특히 여러 개의 Vote를 한 번에 조회할 때, 각 Vote마다 연관 데이터를 개별 쿼리로 가져오는 N+1 문제가 발생했으며, 이는 전체 시스템의 응답 속도를 늦추고 DB에 과도한 부하를 유발했습니다.

이번 개선을 통해 Lazy 로딩 전략을 명시적으로 설정하고, `@BatchSize`를 활용하여 연관 데이터가 필요한 경우에도 IN 절을 통한 배치 쿼리로 묶어서 가져오게 하여 쿼리 횟수를 대폭 감소시켰습니다. 예를 들어, 100개의 Vote를 조회하면서 각 Vote의 댓글을 Lazy 로딩하는 경우, 기존에는 최대 101개의 쿼리가 발생하던 것을 2~3개의 배치 쿼리로 줄일 수 있게 되었습니다.

이를 통해 다음과 같은 성능 향상 효과를 기대할 수 있습니다:

- 불필요한 데이터 로딩 방지로 인해 응답 속도 개선
- 데이터베이스 트래픽 감소
- 메모리 사용량 최적화
- 대규모 요청에서도 확장성 향상
