### PR TITLE
fix: [052-delete-vote] 투표 삭제 시 500 에러 발생 문제 해결

### DIFF
--- a/src/main/java/project/votebackend/repository/voteStat/VoteStat6hRepository.java
+++ b/src/main/java/project/votebackend/repository/voteStat/VoteStat6hRepository.java
@@ -3,6 +3,7 @@ package project.votebackend.repository.voteStat;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
@@ -43,4 +44,8 @@ public interface VoteStat6hRepository extends JpaRepository<VoteStat6h, Long> {
 
     //해당 시간 통계 삭제
     void deleteByStatTime(LocalDateTime statTime);
+
+    @Modifying
+    @Query("DELETE FROM VoteStatHourly v WHERE v.vote.voteId = :voteId")
+    void deleteByVoteId(@Param("voteId") Long voteId);
 }

--- a/src/main/java/project/votebackend/repository/voteStat/VoteStatHourlyRepository.java
+++ b/src/main/java/project/votebackend/repository/voteStat/VoteStatHourlyRepository.java
@@ -3,6 +3,7 @@ package project.votebackend.repository.voteStat;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
@@ -31,4 +32,8 @@ public interface VoteStatHourlyRepository extends JpaRepository<VoteStatHourly, 
 
     // 해당 시간 통계 삭제
     void deleteByStatHour(LocalDateTime statHour);
+
+    @Modifying
+    @Query("DELETE FROM VoteStatHourly v WHERE v.vote.voteId = :voteId")
+    void deleteByVoteId(@Param("voteId") Long voteId);
 }

--- a/src/main/java/project/votebackend/service/vote/VoteService.java
+++ b/src/main/java/project/votebackend/service/vote/VoteService.java
@@ -3,19 +3,12 @@ package project.votebackend.service.vote;
 import co.elastic.clients.elasticsearch.ElasticsearchClient;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageImpl;
-import org.springframework.data.domain.PageRequest;
-import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import project.votebackend.domain.category.Category;
 import project.votebackend.domain.user.User;
-import project.votebackend.domain.vote.Vote;
-import project.votebackend.domain.vote.VoteImage;
-import project.votebackend.domain.vote.VoteOption;
+import project.votebackend.domain.vote.*;
 import project.votebackend.dto.vote.CreateVoteRequest;
-import project.votebackend.dto.vote.LoadVoteDto;
 import project.votebackend.elasticSearch.VoteDocument;
 import project.votebackend.exception.AuthException;
 import project.votebackend.exception.CategoryException;
@@ -25,15 +18,13 @@ import project.votebackend.repository.user.UserRepository;
 import project.votebackend.repository.vote.VoteImageRepository;
 import project.votebackend.repository.vote.VoteOptionRepository;
 import project.votebackend.repository.vote.VoteRepository;
-import project.votebackend.repository.vote.VoteSelectRepository;
+import project.votebackend.repository.voteStat.VoteStat6hRepository;
+import project.votebackend.repository.voteStat.VoteStatHourlyRepository;
 import project.votebackend.type.ErrorCode;
-import project.votebackend.type.ReactionType;
-import project.votebackend.util.VoteStatisticsUtil;
 
 import java.io.IOException;
 import java.time.LocalDateTime;
 import java.util.List;
-import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -44,11 +35,11 @@ public class VoteService {
     private final VoteRepository voteRepository;
     private final UserRepository userRepository;
     private final CategoryRepository categoryRepository;
-    private final VoteSelectRepository voteSelectRepository;
     private final VoteOptionRepository voteOptionRepository;
     private final ElasticsearchClient elasticsearchClient;
     private final VoteImageRepository voteImageRepository;
-    private final VoteStatisticsUtil voteStatisticsUtil;
+    private final VoteStat6hRepository voteStat6hRepository;
+    private final VoteStatHourlyRepository voteStatHourlyRepository;
 
     //투표 생성
     @Transactional
@@ -171,6 +162,9 @@ public class VoteService {
         if (!vote.getUser().getUsername().equals(username)) {
             throw new AuthException(ErrorCode.USER_NOT_MATCHED);
         }
+
+        voteStatHourlyRepository.deleteByVoteId(voteId);
+        voteStat6hRepository.deleteByVoteId(voteId);
 
         voteRepository.delete(vote);
 


### PR DESCRIPTION
📌 관련 이슈
- [052-delete-vote] 투표 삭제
- 외래 키 제약 조건 위반으로 인한 투표 삭제 실패 문제

🔍 작업 내용
- 투표 삭제 시 연관된 vote_stat_hourly 데이터가 외래 키로 인해 삭제되지 않아 오류 발생
- VoteStatHourlyRepository에 @Modifying 쿼리 메서드 추가
- voteRepository.deleteById(voteId) 실행 전 voteStatHourlyRepository.deleteByVoteId(voteId) 호출하도록 수정