### PR TITLE
fix: [053-upload-vote] 투표 저장 후 업로드가 가능하도록 구현

### DIFF
--- a/src/main/java/project/votebackend/controller/vote/VoteController.java
+++ b/src/main/java/project/votebackend/controller/vote/VoteController.java
@@ -21,15 +21,24 @@ public class VoteController {
 
     private final VoteService voteService;
 
-    //투표 생성
+    // 투표 저장
     @PostMapping("/create")
     public ResponseEntity<?> createVote(
             @RequestBody CreateVoteRequest request,
             @AuthenticationPrincipal CustumUserDetails userDetails
     ) {
         Vote created = voteService.createVote(request, userDetails.getId());
-        CreateVoteResponse response = new CreateVoteResponse("success", created.getVoteId());
-        return ResponseEntity.ok(response);
+        return ResponseEntity.ok(new CreateVoteResponse("success", created.getVoteId()));
+    }
+
+    // 투표 업로드
+    @PostMapping("/publish/{voteId}")
+    public ResponseEntity<?> publishVote(
+            @PathVariable Long voteId,
+            @AuthenticationPrincipal CustumUserDetails userDetails
+    ) {
+        voteService.publishVote(voteId, userDetails.getId());
+        return ResponseEntity.ok("success");
     }
 
     // 투표 재업로드

--- a/src/main/java/project/votebackend/domain/vote/Vote.java
+++ b/src/main/java/project/votebackend/domain/vote/Vote.java
@@ -8,6 +8,7 @@ import project.votebackend.domain.category.Category;
 import project.votebackend.domain.comment.Comment;
 import project.votebackend.domain.reaction.Reaction;
 import project.votebackend.domain.user.User;
+import project.votebackend.type.VoteStatus;
 
 import java.time.LocalDateTime;
 import java.util.ArrayList;
@@ -39,6 +40,9 @@ public class Vote extends BaseEntity {
     private String content;
     private String link;
     private LocalDateTime finishTime;
+
+    @Enumerated(EnumType.STRING)
+    private VoteStatus status;
 
     @OneToMany(mappedBy = "vote", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
     @BatchSize(size = 50)

--- a/src/main/java/project/votebackend/dto/vote/LoadVoteDto.java
+++ b/src/main/java/project/votebackend/dto/vote/LoadVoteDto.java
@@ -9,6 +9,7 @@ import project.votebackend.domain.vote.Vote;
 import project.votebackend.domain.vote.VoteOption;
 import project.votebackend.repository.vote.VoteSelectRepository;
 import project.votebackend.type.ReactionType;
+import project.votebackend.type.VoteStatus;
 
 import java.time.LocalDateTime;
 import java.util.Comparator;
@@ -38,6 +39,7 @@ public class LoadVoteDto {
     private int commentCount;
     private int likeCount;
     private String profileImage;
+    private VoteStatus voteStatus;
 
     @JsonProperty("isBookmarked")
     private boolean isBookmarked;
@@ -109,6 +111,7 @@ public class LoadVoteDto {
                 .isBookmarked(isBookmarked)
                 .profileImage(vote.getUser().getProfileImage())
                 .totalVotes(totalVotes)
+                .voteStatus(vote.getStatus())
                 .selectedOptionId(selectedOptionId.orElse(null))
                 .build();
     }

--- a/src/main/java/project/votebackend/service/storage/StorageService.java
+++ b/src/main/java/project/votebackend/service/storage/StorageService.java
@@ -28,14 +28,6 @@ public class StorageService {
         return voteStatisticsUtil.getLoadVoteDtos(userId, votes, stats, pageable);
     }
 
-    //좋아요한 게시물
-    public Page<LoadVoteDto> getLikedPosts(Long userId, Pageable pageable) {
-        Page<Vote> votes = voteRepository.findLikedVotes(userId, pageable);
-        List<Long> voteIds = votes.getContent().stream().map(Vote::getVoteId).toList();
-        Map<String, Object> stats = voteStatisticsUtil.collectVoteStatistics(userId, voteIds);
-        return voteStatisticsUtil.getLoadVoteDtos(userId, votes, stats, pageable);
-    }
-
     //북마크한 게시물
     public Page<LoadVoteDto> getBookmarkedPosts(Long userId, Pageable pageable) {
         Page<Vote> votes = voteRepository.findBookmarkedVotes(userId, pageable);

--- a/src/main/java/project/votebackend/type/VoteStatus.java
+++ b/src/main/java/project/votebackend/type/VoteStatus.java
@@ -1,0 +1,6 @@
+package project.votebackend.type;
+
+public enum VoteStatus {
+    DRAFT, // 임시 저장
+    PUBLISHED // 최종 업로드
+}


### PR DESCRIPTION
### 📌 관련 이슈
- [053-upload-vote]

### 🔍 작업 내용
1. `getCreatedPosts()` 서비스 로직에서 사용되는 `LoadVoteDto.fromEntityWithAllMaps()` 메서드에 `vote.getStatus()` 값을 추가로 포함시킴
2. 마이페이지에서 "내가 작성한 글" 목록을 조회할 때 각 글의 `VoteStatus`(`DRAFT`, `PUBLISHED`)가 함께 전달되도록 변경
3. 프론트엔드에서 글 상태(임시저장 vs 게시 완료) 구분이 가능하도록 지원