### PR TITLE
fix: [052-delete-vote] 투표 삭제 시 외래키 관련 문제 해결

### DIFF
--- a/src/main/java/project/votebackend/repository/voteStat/VoteStat6hRepository.java
+++ b/src/main/java/project/votebackend/repository/voteStat/VoteStat6hRepository.java
@@ -7,6 +7,7 @@ import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
 import project.votebackend.domain.vote.VoteStat6h;
 
 import java.time.LocalDateTime;
@@ -45,7 +46,8 @@ public interface VoteStat6hRepository extends JpaRepository<VoteStat6h, Long> {
     //해당 시간 통계 삭제
     void deleteByStatTime(LocalDateTime statTime);
 
+    @Transactional
     @Modifying
-    @Query("DELETE FROM VoteStatHourly v WHERE v.vote.voteId = :voteId")
+    @Query(value = "DELETE FROM vote_stat_6h WHERE vote_id = :voteId", nativeQuery = true)
     void deleteByVoteId(@Param("voteId") Long voteId);
 }

--- a/src/main/java/project/votebackend/repository/voteStat/VoteStatHourlyRepository.java
+++ b/src/main/java/project/votebackend/repository/voteStat/VoteStatHourlyRepository.java
@@ -7,6 +7,7 @@ import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
 import project.votebackend.domain.vote.VoteStatHourly;
 
 import java.time.LocalDateTime;
@@ -33,7 +34,8 @@ public interface VoteStatHourlyRepository extends JpaRepository<VoteStatHourly, 
     // 해당 시간 통계 삭제
     void deleteByStatHour(LocalDateTime statHour);
 
+    @Transactional
     @Modifying
-    @Query("DELETE FROM VoteStatHourly v WHERE v.vote.voteId = :voteId")
+    @Query(value = "DELETE FROM vote_stat_hourly WHERE vote_id = :voteId", nativeQuery = true)
     void deleteByVoteId(@Param("voteId") Long voteId);
 }

--- a/src/main/java/project/votebackend/service/vote/VoteService.java
+++ b/src/main/java/project/votebackend/service/vote/VoteService.java
@@ -189,9 +189,16 @@ public class VoteService {
         if (!vote.getUser().getUsername().equals(username)) {
             throw new AuthException(ErrorCode.USER_NOT_MATCHED);
         }
-
+        System.out.println("1h start");
         voteStatHourlyRepository.deleteByVoteId(voteId);
+        voteStatHourlyRepository.flush();
+        System.out.println("1h end");
+
+        System.out.println("6h start");
         voteStat6hRepository.deleteByVoteId(voteId);
+        voteStat6hRepository.flush();
+        System.out.println("6h end");
+
 
         voteRepository.delete(vote);
 

--- a/src/main/java/project/votebackend/service/vote/VoteService.java
+++ b/src/main/java/project/votebackend/service/vote/VoteService.java
@@ -189,16 +189,11 @@ public class VoteService {
         if (!vote.getUser().getUsername().equals(username)) {
             throw new AuthException(ErrorCode.USER_NOT_MATCHED);
         }
-        System.out.println("1h start");
         voteStatHourlyRepository.deleteByVoteId(voteId);
         voteStatHourlyRepository.flush();
-        System.out.println("1h end");
 
-        System.out.println("6h start");
         voteStat6hRepository.deleteByVoteId(voteId);
         voteStat6hRepository.flush();
-        System.out.println("6h end");
-
 
         voteRepository.delete(vote);
 


### PR DESCRIPTION
📌 관련 이슈
- [052-delete-vote]

🔍 작업 내용
- 투표 삭제 시 외래 키 제약 오류 해결
- 기존에 vote_stat_6h, vote_stat_hourly 데이터가 삭제되지 않아 vote 삭제가 실패하던 문제 발생
- @Query로 작성된 deleteByVoteId JPQL이 제대로 동작하지 않던 원인을 고려해 Native Query로 수정
- 삭제 쿼리 직후 flush() 호출하여 DB 반영을 보장함
- voteStat6h, voteStatHourly 삭제 → flush → vote 삭제 순으로 정리