### PR TITLE
fix: [010-signup] 회원가입시 등급 저장

### DIFF
--- a/src/main/java/project/votebackend/domain/user/User.java
+++ b/src/main/java/project/votebackend/domain/user/User.java
@@ -4,6 +4,7 @@ import jakarta.persistence.*;
 import lombok.*;
 import project.votebackend.domain.BaseEntity;
 import project.votebackend.type.Gender;
+import project.votebackend.type.Grade;
 
 import java.time.LocalDate;
 import java.util.ArrayList;
@@ -51,6 +52,10 @@ public class User extends BaseEntity {
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)
     private Gender gender;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private Grade grade;
 
     @Column(nullable = false)
     private LocalDate birthdate;

--- a/src/main/java/project/votebackend/service/auth/AuthService.java
+++ b/src/main/java/project/votebackend/service/auth/AuthService.java
@@ -19,6 +19,7 @@ import project.votebackend.repository.category.CategoryRepository;
 import project.votebackend.repository.user.UserInterestRepository;
 import project.votebackend.repository.user.UserRepository;
 import project.votebackend.type.ErrorCode;
+import project.votebackend.type.Grade;
 import project.votebackend.util.JwtUtil;
 
 import java.io.IOException;
@@ -52,6 +53,7 @@ public class AuthService {
                 .password(passwordEncoder.encode(dto.getPassword())) // 비밀번호 암호화
                 .name(dto.getName())
                 .gender(dto.getGender())
+                .grade(Grade.HUNDRED)
                 .phone(dto.getPhone())
                 .birthdate(dto.getBirthdate())
                 .address(dto.getAddress())

--- a/src/main/java/project/votebackend/type/Grade.java
+++ b/src/main/java/project/votebackend/type/Grade.java
@@ -1,0 +1,28 @@
+package project.votebackend.type;
+
+import lombok.Getter;
+
+@Getter
+public enum Grade {
+    HUNDRED("백장"),
+    THOUSAND("천장"),
+    TEN_THOUSAND("만장"),
+    HUNDRED_THOUSAND("십만장"),
+    MILLION("백만장"),
+    TEN_MILLION("천만장");
+
+    private final String label;
+
+    Grade(String label) {
+        this.label = label;
+    }
+
+    public static Grade fromAverage(long avg) {
+        if (avg < 100) return HUNDRED;
+        else if (avg < 1_000) return THOUSAND;
+        else if (avg < 10_000) return TEN_THOUSAND;
+        else if (avg < 100_000) return HUNDRED_THOUSAND;
+        else if (avg < 1_000_000) return MILLION;
+        else return TEN_MILLION;
+    }
+}


### PR DESCRIPTION
### 📌 관련 이슈
- [010-signup]

### 🔍 작업 내용
1. 회원가입시 등급이 저장되도록
2. 등급은 우선적으로(백장, 천장, 만장, 십만장, 백만장, 천만장) 으로 구성
3. 회원가입시에는 백장으로 저장
