### PR TITLE
fix: [054-edit-vote] 투표 수정시 이미지가 중복하여 저장되는 현상 수정

### DIFF
--- a/src/main/java/project/votebackend/repository/vote/VoteImageRepository.java
+++ b/src/main/java/project/votebackend/repository/vote/VoteImageRepository.java
@@ -6,4 +6,5 @@ import project.votebackend.domain.vote.VoteImage;
 
 @Repository
 public interface VoteImageRepository extends JpaRepository<VoteImage, Long> {
+    void deleteByVote_VoteId(Long voteId);
 }

--- a/src/main/java/project/votebackend/service/vote/VoteService.java
+++ b/src/main/java/project/votebackend/service/vote/VoteService.java
@@ -256,16 +256,16 @@ public class VoteService {
         }
 
         // 기존 이미지 삭제
+        voteImageRepository.deleteByVote_VoteId(voteId);
         vote.getImages().clear();
 
-        // 새로운 이미지 추가
-        if (request.getImageUrls() != null) {
-            for (String url : request.getImageUrls()) {
-                VoteImage img = new VoteImage();
-                img.setVote(vote);
-                img.setImageUrl(url);
-                vote.getImages().add(img);
-            }
+        // 첫 번째 이미지만 추가
+        if (request.getImageUrls() != null && !request.getImageUrls().isEmpty()) {
+            String url = request.getImageUrls().get(0);
+            VoteImage img = new VoteImage();
+            img.setVote(vote);
+            img.setImageUrl(url);
+            vote.getImages().add(img);
         }
 
         voteRepository.save(vote);


### PR DESCRIPTION
📌 관련 이슈
- [054-edit-vote] 

🔍 작업 내용
- Vote 이미지 수정 로직 개선
- 기존에는 이미지 삭제 후 새로 등록하는 과정에서 이미지 삭제가 안됨(vote entity에서의 이미지는 삭제하였지만 실제 vote image entity에서는 삭제가 안되는 현상 발견)
- VoteImageRepository에 삭제 메서드 추가

