### PR TITLE
feat: [013-create-vote] 투표 생성시 TEXT, IMAGE, VIDEO 타입 선택

### DIFF
--- a/src/main/java/project/votebackend/domain/vote/Vote.java
+++ b/src/main/java/project/votebackend/domain/vote/Vote.java
@@ -9,6 +9,7 @@ import project.votebackend.domain.comment.Comment;
 import project.votebackend.domain.reaction.Reaction;
 import project.votebackend.domain.user.User;
 import project.votebackend.type.VoteStatus;
+import project.votebackend.type.VoteType;
 
 import java.time.LocalDateTime;
 import java.util.ArrayList;
@@ -43,6 +44,9 @@ public class Vote extends BaseEntity {
 
     @Enumerated(EnumType.STRING)
     private VoteStatus status;
+
+    @Enumerated(EnumType.STRING)
+    private VoteType voteType;
 
     @OneToMany(mappedBy = "vote", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
     @BatchSize(size = 50)

--- a/src/main/java/project/votebackend/dto/vote/CreateVoteRequest.java
+++ b/src/main/java/project/votebackend/dto/vote/CreateVoteRequest.java
@@ -12,6 +12,7 @@ public class CreateVoteRequest {
     private String title;
     private String content;
     private String link;
+    private String voteType;
     private LocalDateTime finishTime;
     private List<VoteOptionDto> options;
     private List<String> imageUrls;

--- a/src/main/java/project/votebackend/dto/vote/LoadVoteDto.java
+++ b/src/main/java/project/votebackend/dto/vote/LoadVoteDto.java
@@ -10,6 +10,7 @@ import project.votebackend.domain.vote.VoteOption;
 import project.votebackend.repository.vote.VoteSelectRepository;
 import project.votebackend.type.ReactionType;
 import project.votebackend.type.VoteStatus;
+import project.votebackend.type.VoteType;
 
 import java.time.LocalDateTime;
 import java.util.Comparator;
@@ -40,6 +41,7 @@ public class LoadVoteDto {
     private int likeCount;
     private String profileImage;
     private VoteStatus voteStatus;
+    private VoteType voteType;
 
     @JsonProperty("isBookmarked")
     private boolean isBookmarked;
@@ -112,6 +114,7 @@ public class LoadVoteDto {
                 .profileImage(vote.getUser().getProfileImage())
                 .totalVotes(totalVotes)
                 .voteStatus(vote.getStatus())
+                .voteType(vote.getVoteType())
                 .selectedOptionId(selectedOptionId.orElse(null))
                 .build();
     }

--- a/src/main/java/project/votebackend/dto/vote/UpdateVoteRequest.java
+++ b/src/main/java/project/votebackend/dto/vote/UpdateVoteRequest.java
@@ -11,6 +11,7 @@ public class UpdateVoteRequest {
     private String title;
     private String content;
     private String link;
+    private String voteType;
     private LocalDateTime finishTime;
     private List<VoteOptionDto> options;
     private List<String> imageUrls;

--- a/src/main/java/project/votebackend/service/vote/VoteService.java
+++ b/src/main/java/project/votebackend/service/vote/VoteService.java
@@ -25,6 +25,7 @@ import project.votebackend.repository.voteStat.VoteStat6hRepository;
 import project.votebackend.repository.voteStat.VoteStatHourlyRepository;
 import project.votebackend.type.ErrorCode;
 import project.votebackend.type.VoteStatus;
+import project.votebackend.type.VoteType;
 
 import java.io.IOException;
 import java.time.LocalDateTime;
@@ -55,11 +56,19 @@ public class VoteService {
         Category category = categoryRepository.findById(request.getCategoryId())
                 .orElseThrow(() -> new CategoryException(ErrorCode.CATEGORY_NOT_FOUND));
 
+        VoteType voteType;
+        try {
+            voteType = VoteType.valueOf(request.getVoteType().toUpperCase());
+        } catch (IllegalArgumentException e) {
+            throw new IllegalArgumentException("Invalid voteType. Allowed values: TEXT, IMAGE, VIDEO");
+        }
+
         Vote vote = Vote.builder()
                 .title(request.getTitle())
                 .content(request.getContent())
                 .finishTime(request.getFinishTime())
                 .status(VoteStatus.DRAFT)
+                .voteType(voteType)
                 .build();
 
         vote.setUser(user);
@@ -146,6 +155,7 @@ public class VoteService {
         newVote.setContent(original.getContent());
         newVote.setCategory(original.getCategory());
         newVote.setUser(original.getUser());
+        newVote.setVoteType(original.getVoteType());
         newVote.setFinishTime(newFinishTime);
         voteRepository.save(newVote);
 
@@ -231,10 +241,18 @@ public class VoteService {
             vote.setCategory(category);
         }
 
+        VoteType voteType;
+        try {
+            voteType = VoteType.valueOf(request.getVoteType().toUpperCase());
+        } catch (IllegalArgumentException e) {
+            throw new IllegalArgumentException("Invalid voteType. Allowed values: TEXT, IMAGE, VIDEO");
+        }
+
         // 기본 필드 수정
         vote.setTitle(request.getTitle());
         vote.setContent(request.getContent());
         vote.setLink(request.getLink());
+        vote.setVoteType(voteType);
         vote.setFinishTime(request.getFinishTime());
 
         // 기존 옵션에 대한 투표 기록 삭제

--- a/src/main/java/project/votebackend/type/VoteType.java
+++ b/src/main/java/project/votebackend/type/VoteType.java
@@ -1,0 +1,5 @@
+package project.votebackend.type;
+
+public enum VoteType {
+    TEXT, IMAGE, VIDEO
+}


### PR DESCRIPTION
📌 관련 이슈
- [013-create-vote]

🔍 작업 내용
- voteType 필드를 생성(Create), 수정(Update), 재업로드(Reupload) 로직에 모두 적용
- CreateVoteRequest로부터 받아서 Vote에 저장
- UpdateVoteRequest에서 받은 값으로 기존 투표의 voteType 업데이트
- reuploadVote 시 기존 투표의 voteType을 새 투표에 복사
- LoadVoteDto에 voteType 추가하여 프론트에서 타입별 분기 가능하게 개선

→ 투표 타입(TEXT/IMAGE/VIDEO)에 따라 프론트에서 다르게 렌더링하기 위한 사전 작업

