### PR TITLE
feat: [054-vote-ranking] 투표 순위 로직 추가

### DIFF
--- a/src/main/java/project/votebackend/domain/vote/VoteStat6h.java
+++ b/src/main/java/project/votebackend/domain/vote/VoteStat6h.java
@@ -36,4 +36,10 @@ public class VoteStat6h extends BaseEntity {
     private int rankChangeTotal;            // 누적 득표 순위 변화
     private int rankChangeToday;            // 오늘 득표 순위 변화
     private int rankChangeComment;          // 댓글 순위 변화
+
+    private int ongoingCommentRank;         // 진행중인 투표 댓글 수 랭킹
+    private int ongoingVoteCountRank;       // 진행중인 투표 투표 수 랭킹
+
+    private int ongoingCommentRankChange;   // 진행중인 투표 댓글 수 랭킹 변화
+    private int ongoingVoteCountRankChange; // 진행중인 투표 투표 수 랭킹 변화
 }

--- a/src/main/java/project/votebackend/dto/vote/VoteSummaryDto.java
+++ b/src/main/java/project/votebackend/dto/vote/VoteSummaryDto.java
@@ -26,4 +26,10 @@ public class VoteSummaryDto {
     private int rankChangeTotal;         // 누적 득표 순위 변화
     private int rankChangeToday;         // 오늘 득표 순위 변화
     private int rankChangeComment;
+
+    private int ongoingCommentRank;         // 진행중인 투표 댓글 수 랭킹
+    private int ongoingVoteCountRank;       // 진행중인 투표 투표 수 랭킹
+
+    private int ongoingCommentRankChange;   // 진행중인 투표 댓글 수 랭킹 변화
+    private int ongoingVoteCountRankChange; // 진행중인 투표 투표 수 랭킹 변화
 }

--- a/src/main/java/project/votebackend/repository/voteStat/VoteStat6hRepository.java
+++ b/src/main/java/project/votebackend/repository/voteStat/VoteStat6hRepository.java
@@ -30,11 +30,11 @@ public interface VoteStat6hRepository extends JpaRepository<VoteStat6h, Long> {
     // 진행중인 투표 댓글수 기준 정렬
     Page<VoteStat6h> findByStatTimeAndVote_FinishTimeAfterOrderByCommentCountDesc(LocalDateTime statTime, LocalDateTime now, Pageable pageable);
 
-    // 진행중인 투표 전체 득표수 기준 정렬
-    Page<VoteStat6h> findByStatTimeAndVote_FinishTimeLessThanEqualOrderByTotalVoteCountDesc(LocalDateTime statTime, LocalDateTime now, Pageable pageable);
+    // 전체 득표수 기준 정렬
+    Page<VoteStat6h> findByStatTimeOrderByTotalVoteCountDesc(LocalDateTime statTime, Pageable pageable);
 
-    // 진행중인 투표 댓글수 기준 정렬
-    Page<VoteStat6h> findByStatTimeAndVote_FinishTimeLessThanEqualOrderByCommentCountDesc(LocalDateTime statTime, LocalDateTime now, Pageable pageable);
+    // 댓글수 기준 정렬
+    Page<VoteStat6h> findByStatTimeOrderByCommentCountDesc(LocalDateTime statTime, Pageable pageable);
 
     // 이전 1시간 단위 시간 조회
     @Query("SELECT MAX(v.statTime) FROM VoteStat6h v WHERE v.statTime < :now")


### PR DESCRIPTION
### 📌 관련 이슈
- [054-vote-ranking]

### 🔍 작업 내용
1. `VoteStat6h` 도메인에 진행 중 투표 전용 랭킹 및 랭킹 변화량 필드 4개 추가
   - `ongoingCommentRank`, `ongoingVoteCountRank`
   - `ongoingCommentRankChange`, `ongoingVoteCountRankChange`
2. 스케줄러 `generate6hStats()` 로직 내에서
   - 진행 중 투표만 필터링 후 별도로 정렬
   - 댓글 수 / 득표 수 기준으로 각각 랭킹 부여
   - 직전 통계와 비교하여 변화량 계산 및 저장
