### PR TITLE
fix: [054-vote-ranking] 진행 중인 투표의 총 투표수, 댓글 수 순위 계산 로직 수정

### DIFF
--- a/src/main/java/project/votebackend/service/vote/VoteSchedulingService.java
+++ b/src/main/java/project/votebackend/service/vote/VoteSchedulingService.java
@@ -116,9 +116,9 @@ public class VoteSchedulingService {
         for (int i = 0; i < stats.size(); i++) {
             VoteStat6h stat = stats.get(i);
             int score = switch (type) {
-                case "total" -> stat.getTotalVoteCount();
+                case "total", "ongoingVote" -> stat.getTotalVoteCount();
                 case "today" -> stat.getTodayVoteCount();
-                case "comment" -> stat.getCommentCount();
+                case "comment", "ongoingComment" -> stat.getCommentCount();
                 default -> throw new IllegalArgumentException("Invalid type");
             };
 
@@ -127,9 +127,9 @@ public class VoteSchedulingService {
             }
 
             switch (type) {
-                case "total" -> stat.setRankTotal(rank);
+                case "total", "ongoingVote" -> stat.setRankTotal(rank);
                 case "today" -> stat.setRankToday(rank);
-                case "comment" -> stat.setRankComment(rank);
+                case "comment", "ongoingComment" -> stat.setRankComment(rank);
             }
 
             prevScore = score;


### PR DESCRIPTION
### 📌 관련 이슈
- [054-vote-ranking]

### 🔍 작업 내용
- `assignRanks` 메서드의 switch문에 `ongoingVote`, `ongoingComment`를 추가하여 진행 중인 투표의 순위가 측정되도록 수정