### PR TITLE
feat: [054-vote-ranking] 전체 투표, 댓글 순 정렬(종료된 투표에 한하여)

### DIFF
--- a/src/main/java/project/votebackend/domain/vote/VoteStat6h.java
+++ b/src/main/java/project/votebackend/domain/vote/VoteStat6h.java
@@ -42,4 +42,10 @@ public class VoteStat6h extends BaseEntity {
 
     private int ongoingCommentRankChange;   // 진행중인 투표 댓글 수 랭킹 변화
     private int ongoingVoteCountRankChange; // 진행중인 투표 투표 수 랭킹 변화
+
+    private int endedCommentRank;         // 종료된 투표 댓글 수 랭킹
+    private int endedVoteCountRank;       // 종료된 투표 투표 수 랭킹
+
+    private int endedCommentRankChange;   // 종료된 투표 댓글 수 랭킹 변화
+    private int endedVoteCountRankChange; // 종료된 투표 투표 수 랭킹 변화
 }

--- a/src/main/java/project/votebackend/dto/vote/VoteSummaryDto.java
+++ b/src/main/java/project/votebackend/dto/vote/VoteSummaryDto.java
@@ -32,4 +32,10 @@ public class VoteSummaryDto {
 
     private int ongoingCommentRankChange;   // 진행중인 투표 댓글 수 랭킹 변화
     private int ongoingVoteCountRankChange; // 진행중인 투표 투표 수 랭킹 변화
+
+    private int endedCommentRank;         // 종료된 투표 댓글 수 랭킹
+    private int endedVoteCountRank;       // 종료된 투표 투표 수 랭킹
+
+    private int endedCommentRankChange;   // 종료된 투표 댓글 수 랭킹 변화
+    private int endedVoteCountRankChange; // 종료된 투표 투표 수 랭킹 변화
 }

--- a/src/main/java/project/votebackend/repository/voteStat/VoteStat6hRepository.java
+++ b/src/main/java/project/votebackend/repository/voteStat/VoteStat6hRepository.java
@@ -1,6 +1,7 @@
 package project.votebackend.repository.voteStat;
 
 import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
@@ -11,6 +12,7 @@ import org.springframework.transaction.annotation.Transactional;
 import project.votebackend.domain.vote.VoteStat6h;
 
 import java.time.LocalDateTime;
+import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 
@@ -29,6 +31,12 @@ public interface VoteStat6hRepository extends JpaRepository<VoteStat6h, Long> {
 
     // 진행중인 투표 댓글수 기준 정렬
     Page<VoteStat6h> findByStatTimeAndVote_FinishTimeAfterOrderByCommentCountDesc(LocalDateTime statTime, LocalDateTime now, Pageable pageable);
+
+    // 종료된 투표 전체 투표수 기준 정렬
+    Page<VoteStat6h> findByStatTimeAndVote_FinishTimeBeforeOrderByTotalVoteCountDesc(LocalDateTime latest, LocalDateTime now, Pageable pageable);
+
+    // 종료된 투표 댓글수 기준 정렬
+    Page<VoteStat6h> findByStatTimeAndVote_FinishTimeBeforeOrderByCommentCountDesc(LocalDateTime latest, LocalDateTime now, Pageable pageable);
 
     // 전체 득표수 기준 정렬
     Page<VoteStat6h> findByStatTimeOrderByTotalVoteCountDesc(LocalDateTime statTime, Pageable pageable);

--- a/src/main/java/project/votebackend/service/vote/VoteRankingService.java
+++ b/src/main/java/project/votebackend/service/vote/VoteRankingService.java
@@ -40,8 +40,13 @@ public class VoteRankingService {
             return voteStat6hRepository
                     .findByStatTimeAndVote_FinishTimeAfterOrderByTotalVoteCountDesc(latest, now, pageable)
                     .stream().map(this::toDto).toList();
+        } else if (status == VoteStatusType.ENDED) {
+            // 종료 된 투표만
+            return voteStat6hRepository
+                    .findByStatTimeAndVote_FinishTimeBeforeOrderByTotalVoteCountDesc(latest, now, pageable)
+                    .stream().map(this::toDto).toList();
         } else {
-            // 종료된 투표 포함 전체 (종료만 or 전체)
+            // 전체 (전체)
             return voteStat6hRepository
                     .findByStatTimeOrderByTotalVoteCountDesc(latest, pageable)
                     .stream().map(this::toDto).toList();
@@ -69,8 +74,13 @@ public class VoteRankingService {
             return voteStat6hRepository
                     .findByStatTimeAndVote_FinishTimeAfterOrderByCommentCountDesc(latest, now, pageable)
                     .stream().map(this::toDto).toList();
+        } else if (status == VoteStatusType.ENDED) {
+            // 종료 된 투표만
+            return voteStat6hRepository
+                    .findByStatTimeAndVote_FinishTimeBeforeOrderByCommentCountDesc(latest, now, pageable)
+                    .stream().map(this::toDto).toList();
         } else {
-            // 종료된 투표 포함 전체 (종료만 or 전체)
+            // 전체
             return voteStat6hRepository
                     .findByStatTimeOrderByCommentCountDesc(latest, pageable)
                     .stream().map(this::toDto).toList();
@@ -126,6 +136,10 @@ public class VoteRankingService {
                 .ongoingCommentRankChange(stat.getOngoingCommentRankChange())
                 .ongoingVoteCountRank(stat.getOngoingVoteCountRank())
                 .ongoingVoteCountRankChange(stat.getOngoingVoteCountRankChange())
+                .endedCommentRank(stat.getEndedCommentRank())
+                .endedCommentRankChange(stat.getEndedCommentRankChange())
+                .endedVoteCountRank(stat.getEndedVoteCountRank())
+                .endedVoteCountRankChange(stat.getEndedVoteCountRankChange())
                 .finishTime(vote.getFinishTime())
                 .build();
     }


### PR DESCRIPTION
### 📌 관련 이슈
- [054-vote-ranking]

### 🔍 작업 내용
1. `VoteStat6h` 4개의 컬럼 추가
- 종료된 투표 댓글 수 랭킹
- 종료된 투표 총투표 수 랭킹
- 종료된 투표 댓글 수 랭킹 변화
- 종료된 투표 총투표 수 랭킹 변화

2. 종료된 투표 중, 댓글 수 랭킹 및 랭킹 변화 조회 API추가
3. 종료된 투표 중, 총투표 수 랭킹 및 랭킹 변화 조회 API추가


