### PR TITLE
feat: [054-vote-ranking] 전체 투표, 댓글 순 정렬 스케줄러 추가(종료된 투표)

### DIFF
--- a/src/main/java/project/votebackend/scheduler/VoteStatScheduler.java
+++ b/src/main/java/project/votebackend/scheduler/VoteStatScheduler.java
@@ -22,7 +22,7 @@ public class VoteStatScheduler {
     // 1시간 단위 관심 급등 통계 갱신
     @Scheduled(cron = "0 2 * * * *")
     public void runHourlyTrendingStatUpdate() {
-        log.info("[스케줄] 6시간 단위 관심 급등 통계 시작");
+        log.info("[스케줄] 1시간 단위 관심 급등 통계 시작");
         voteSchedulingService.generateHourlyStats();
     }
 }


### PR DESCRIPTION
### 📌 관련 이슈
- [054-vote-ranking]

### 🔍 작업 내용
- 6시간 단위 통계 생성 로직(generate6hStats)에 종료된 투표 전용 랭킹 계산 로직 추가
  - 종료된 투표만 필터링하여 리스트 구성 (endedStats)
  - endedAssignRanks() 메서드로 랭킹 계산
  - 이전 통계와 비교하여 rankChange 필드 계산
  - 기존 진행 중 투표 랭킹 로직(ongoingAssignRanks) 구조와 동일한 방식으로 구현
