### PR TITLE
feat: [058-search-query] 검색 쿼리문 변환

### DIFF
--- a/src/main/java/project/votebackend/controller/search/SearchController.java
+++ b/src/main/java/project/votebackend/controller/search/SearchController.java
@@ -1,10 +1,14 @@
 package project.votebackend.controller.search;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+import project.votebackend.dto.vote.VoteSearchResponse;
 import project.votebackend.elasticSearch.UserDocument;
 import project.votebackend.elasticSearch.VoteDocument;
 import project.votebackend.service.elasticsearch.SearchService;
@@ -19,11 +23,20 @@ public class SearchController {
 
     private final SearchService searchService;
 
-    //투표 검색어 입력
+    //쿼리문을 이용한 투표 검색
     @GetMapping("/vote")
-    public List<VoteDocument> searchVotes(@RequestParam("keyword") String keyword) throws IOException {
-        return searchService.searchVotes(keyword);
+    public Page<VoteSearchResponse> searchVotes(
+            @RequestParam("keyword") String keyword,
+            @PageableDefault(size = 20, page = 0) Pageable pageable
+    ) {
+        return searchService.searchVotes(keyword, pageable);
     }
+
+//    //투표 검색어 입력
+//    @GetMapping("/vote")
+//    public List<VoteDocument> searchVotes(@RequestParam("keyword") String keyword) throws IOException {
+//        return searchService.searchVotes(keyword);
+//    }
 
     //유저 검색어 입력
     @GetMapping("/user")

--- a/src/main/java/project/votebackend/dto/vote/VoteSearchResponse.java
+++ b/src/main/java/project/votebackend/dto/vote/VoteSearchResponse.java
@@ -1,0 +1,14 @@
+package project.votebackend.dto.vote;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class VoteSearchResponse {
+    private Long id;
+    private String title;
+    private int totalVotes;
+    private int likeCount;
+    private int commentCount;
+}


### PR DESCRIPTION
📌 관련 이슈
- [058-search-query]

🔍 작업 내용
- 투표 제목 검색 기능을 쿼리문 기반으로 구현
  - @Query(nativeQuery = true) 방식으로 ILIKE 검색 + 참여자 수 / 좋아요 수 / 댓글 수 집계
  - Pageable을 파라미터로 받아 페이징 처리 적용
  - 응답은 VoteSearchResponse DTO로 매핑
- 왜 이렇게 변경했는지
  - 기존 Elasticsearch 방식 제거 후 PostgreSQL로 전환
  - 프론트에서 keyword 기반 검색 결과를 빠르게 페이징 처리하고 요약 정보를 제공하기 위함
  - 성능 최적화를 위해 GIN 인덱스 및 JOIN+GROUP BY 구조로 설계