### PR TITLE
feat: [059-login] refresh token 발급

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -50,6 +50,8 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-mail'
 
     implementation 'software.amazon.awssdk:s3:2.20.30'
+
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 }
 
 tasks.named('test') {

--- a/src/main/java/project/votebackend/config/RedisConfig.java
+++ b/src/main/java/project/votebackend/config/RedisConfig.java
@@ -1,0 +1,38 @@
+package project.votebackend.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@Configuration
+public class RedisConfig {
+
+    @Value("${spring.data.redis.host}")
+    private String redisHost;
+
+    @Value("${spring.data.redis.port}")
+    private int redisPort;
+
+    // Redis 연결 팩토리 설정
+    @Bean
+    public RedisConnectionFactory redisConnectionFactory() {
+        return new LettuceConnectionFactory(redisHost, redisPort);
+    }
+
+    // RedisTemplate 설정 - String(String key, String value) 전용
+    @Bean
+    public RedisTemplate<String, String> redisTemplate(RedisConnectionFactory redisConnectionFactory) {
+        RedisTemplate<String, String> template = new RedisTemplate<>();
+        template.setConnectionFactory(redisConnectionFactory);
+
+        // 직렬화 설정 (Key와 Value 모두 문자열로 저장)
+        template.setKeySerializer(new StringRedisSerializer());
+        template.setValueSerializer(new StringRedisSerializer());
+
+        return template;
+    }
+}


### PR DESCRIPTION
### 📌 관련 이슈
- [059-login]

### 🔍 작업 내용
- JWT 기반 로그인 및 Refresh Token 처리 구현
  - 로그인 시 Access Token과 Refresh Token 생성
  - Access Token은 응답 바디에, Refresh Token은 HttpOnly 쿠키에 저장
  - Refresh Token은 Redis에 RT:{userId} 형태로 저장 (TTL: 7일)
- Access Token 만료 시 Refresh API를 통해 갱신
  - 쿠키에서 Refresh Token 추출 후 유효성 검증
  - Redis에 저장된 토큰과 비교하여 일치할 경우 새 Access Token 발급
- 로그아웃 시 Redis에서 Refresh Token 삭제 및 쿠키 만료 처리
  - 보안을 위해 Refresh Token도 제거