### PR TITLE
fix: [054-vote-ranking] 투표 순위 수정

### DIFF
--- a/src/main/java/project/votebackend/controller/vote/VoteRankingController.java
+++ b/src/main/java/project/votebackend/controller/vote/VoteRankingController.java
@@ -27,11 +27,19 @@ public class VoteRankingController {
         return voteRankingService.getVotesSortedByTotalVotes(status, page, size);
     }
 
-    //오늘 득표순 정렬
-    @GetMapping("/today")
-    public List<VoteSummaryDto> getTodayPopularVotes(@RequestParam(defaultValue = "0") int page,
-                                                     @RequestParam(defaultValue = "20") int size) {
-        return voteRankingService.getVotesSortedByTodayVotes(page, size);
+//    //오늘 득표순 정렬
+//    @GetMapping("/today")
+//    public List<VoteSummaryDto> getTodayPopularVotes(@RequestParam(defaultValue = "0") int page,
+//                                                     @RequestParam(defaultValue = "20") int size) {
+//        return voteRankingService.getVotesSortedByTodayVotes(page, size);
+//    }
+
+    //좋아요순 정렬
+    @GetMapping("/likes")
+    public List<VoteSummaryDto> getMostLikedVotes(@RequestParam VoteStatusType status,
+                                                @RequestParam(defaultValue = "0") int page,
+                                                @RequestParam(defaultValue = "20") int size) {
+        return voteRankingService.getVotesSortedByLikes(status, page, size);
     }
 
     //댓글순 정렬

--- a/src/main/java/project/votebackend/dto/vote/VoteSummaryDto.java
+++ b/src/main/java/project/votebackend/dto/vote/VoteSummaryDto.java
@@ -1,8 +1,13 @@
 package project.votebackend.dto.vote;
 
 import lombok.*;
+import project.votebackend.domain.vote.Vote;
+import project.votebackend.domain.vote.VoteImage;
+import project.votebackend.domain.vote.VoteOption;
+import project.votebackend.type.ReactionType;
 
 import java.time.LocalDateTime;
+import java.util.Optional;
 
 @Getter
 @Setter
@@ -15,27 +20,59 @@ public class VoteSummaryDto {
     private String thumbnailImageUrl;
 
     private int totalVotes;              // 누적 투표 수
-    private int todayVotes;              // 오늘 투표 수
+//    private int todayVotes;              // 오늘 투표 수
     private int commentCount;            // 댓글 수
-    private LocalDateTime finishTime;
+    private int likeCount;               // 좋아요 수
+//    private LocalDateTime finishTime;
 
-    private int rankTotal;               // 누적 투표 기준 랭킹
-    private int rankToday;               // 오늘 득표 기준 랭킹
-    private int rankComment;             // 댓글 기준 랭킹
+//    private int rankTotal;               // 누적 투표 기준 랭킹
+//    private int rankToday;               // 오늘 득표 기준 랭킹
+//    private int rankComment;             // 댓글 기준 랭킹
 
-    private int rankChangeTotal;         // 누적 득표 순위 변화
-    private int rankChangeToday;         // 오늘 득표 순위 변화
-    private int rankChangeComment;
+//    private int rankChangeTotal;         // 누적 득표 순위 변화
+//    private int rankChangeToday;         // 오늘 득표 순위 변화
+//    private int rankChangeComment;
 
-    private int ongoingCommentRank;         // 진행중인 투표 댓글 수 랭킹
-    private int ongoingVoteCountRank;       // 진행중인 투표 투표 수 랭킹
+//    private int ongoingCommentRank;         // 진행중인 투표 댓글 수 랭킹
+//    private int ongoingVoteCountRank;       // 진행중인 투표 투표 수 랭킹
+//
+//    private int ongoingCommentRankChange;   // 진행중인 투표 댓글 수 랭킹 변화
+//    private int ongoingVoteCountRankChange; // 진행중인 투표 투표 수 랭킹 변화
+//
+//    private int endedCommentRank;         // 종료된 투표 댓글 수 랭킹
+//    private int endedVoteCountRank;       // 종료된 투표 투표 수 랭킹
+//
+//    private int endedCommentRankChange;   // 종료된 투표 댓글 수 랭킹 변화
+//    private int endedVoteCountRankChange; // 종료된 투표 투표 수 랭킹 변화
 
-    private int ongoingCommentRankChange;   // 진행중인 투표 댓글 수 랭킹 변화
-    private int ongoingVoteCountRankChange; // 진행중인 투표 투표 수 랭킹 변화
+    // 투표에 등록된 첫 이미지 썸네일 반환
+    private static String extractThumbnail(Vote vote) {
+        Optional<String> imageUrl = vote.getImages().stream()
+                .findFirst()
+                .map(VoteImage::getImageUrl); // Optional<String>
 
-    private int endedCommentRank;         // 종료된 투표 댓글 수 랭킹
-    private int endedVoteCountRank;       // 종료된 투표 투표 수 랭킹
+        if (imageUrl.isPresent()) {
+            return imageUrl.get();
+        }
 
-    private int endedCommentRankChange;   // 종료된 투표 댓글 수 랭킹 변화
-    private int endedVoteCountRankChange; // 종료된 투표 투표 수 랭킹 변화
+        // 이미지가 없다면 옵션 이미지 중 첫 번째
+        return vote.getOptions().stream()
+                .map(VoteOption::getOptionImage)
+                .filter(img -> img != null && !img.isEmpty())
+                .findFirst()
+                .orElse(null); // 또는 기본 이미지 URL
+    }
+
+    public static VoteSummaryDto from(Vote vote) {
+        return VoteSummaryDto.builder()
+                .voteId(vote.getVoteId())
+                .title(vote.getTitle())
+                .thumbnailImageUrl(VoteSummaryDto.extractThumbnail(vote))
+                .totalVotes(vote.getSelections().size())
+                .commentCount((int) vote.getComments().stream().filter(c -> c.getParent() == null).count())
+                .likeCount((int) vote.getReactions().stream()
+                        .filter(r -> r.getReaction() == ReactionType.LIKE)
+                        .count())
+                .build();
+    }
 }

--- a/src/main/java/project/votebackend/repository/vote/VoteRepository.java
+++ b/src/main/java/project/votebackend/repository/vote/VoteRepository.java
@@ -160,6 +160,46 @@ public interface VoteRepository extends JpaRepository<Vote, Long> {
     """)
     List<Vote> findAllWithSelections();
 
+    //총투표수 기준 정렬
+    @Query("""
+        SELECT v
+        FROM Vote v
+        LEFT JOIN v.selections s
+        WHERE
+            (:status = 'ALL')
+            OR (:status = 'ONGOING' AND v.finishTime > CURRENT_TIMESTAMP)
+            OR (:status = 'ENDED' AND v.finishTime <= CURRENT_TIMESTAMP)
+        GROUP BY v
+        ORDER BY COUNT(s) DESC
+    """)
+    List<Vote> findVotesSortedByTotalVotes(@Param("status") String status, Pageable pageable);
+
+    // 댓글 수 기준 정렬
+    @Query("""
+        SELECT v FROM Vote v
+        LEFT JOIN v.comments c
+        WHERE 
+            (:status = 'ALL')
+            OR (:status = 'ONGOING' AND v.finishTime > CURRENT_TIMESTAMP)
+            OR (:status = 'ENDED' AND v.finishTime <= CURRENT_TIMESTAMP)
+        GROUP BY v
+        ORDER BY COUNT(c) DESC
+    """)
+    List<Vote> findVotesSortedByComments(@Param("status") String status, Pageable pageable);
+
+    // 좋아요 수 기준 정렬 (Reaction에서 LIKE만 세기)
+    @Query("""
+        SELECT v FROM Vote v
+        LEFT JOIN v.reactions r WITH r.reaction = 'LIKE'
+        WHERE 
+            (:status = 'ALL')
+            OR (:status = 'ONGOING' AND v.finishTime > CURRENT_TIMESTAMP)
+            OR (:status = 'ENDED' AND v.finishTime <= CURRENT_TIMESTAMP)
+        GROUP BY v
+        ORDER BY COUNT(r) DESC
+    """)
+    List<Vote> findVotesSortedByLikes(@Param("status") String status, Pageable pageable);
+
     // 최근 10개의 투표 조회
     List<Vote> findTop10ByUser_UserIdOrderByCreatedAtDesc(Long userId);
 

--- a/src/main/java/project/votebackend/scheduler/VoteStatScheduler.java
+++ b/src/main/java/project/votebackend/scheduler/VoteStatScheduler.java
@@ -12,15 +12,15 @@ import project.votebackend.service.vote.VoteSchedulingService;
 public class VoteStatScheduler {
     private final VoteSchedulingService voteSchedulingService;
 
-    // 6시간 단위 통계 갱신
-    @Scheduled(cron = "0 0 */6 * * *") // 매일 0시, 6시, 12시, 18시
-    public void run6hVoteStatUpdate() {
-        log.info("[스케줄] 6시간 단위 통계 시작");
-        voteSchedulingService.generate6hStats();
-    }
+//    // 6시간 단위 통계 갱신
+//    @Scheduled(cron = "0 0 */6 * * *") // 매일 0시, 6시, 12시, 18시
+//    public void run6hVoteStatUpdate() {
+//        log.info("[스케줄] 6시간 단위 통계 시작");
+//        voteSchedulingService.generate6hStats();
+//    }
 
     // 1시간 단위 관심 급등 통계 갱신
-    @Scheduled(cron = "0 2 * * * *")
+    @Scheduled(cron = "0 0 * * * *")
     public void runHourlyTrendingStatUpdate() {
         log.info("[스케줄] 1시간 단위 관심 급등 통계 시작");
         voteSchedulingService.generateHourlyStats();

--- a/src/main/java/project/votebackend/service/vote/VoteRankingService.java
+++ b/src/main/java/project/votebackend/service/vote/VoteRankingService.java
@@ -2,11 +2,15 @@ package project.votebackend.service.vote;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import project.votebackend.domain.vote.Vote;
+import project.votebackend.domain.vote.VoteImage;
+import project.votebackend.domain.vote.VoteOption;
 import project.votebackend.domain.vote.VoteStat6h;
 import project.votebackend.dto.vote.TrendingVoteDto;
 import project.votebackend.dto.vote.VoteSummaryDto;
+import project.votebackend.repository.vote.VoteRepository;
 import project.votebackend.repository.voteStat.VoteStat6hRepository;
 import project.votebackend.repository.voteStat.VoteStatHourlyRepository;
 import project.votebackend.type.VoteStatusType;
@@ -14,78 +18,115 @@ import project.votebackend.type.VoteStatusType;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.List;
+import java.util.Optional;
 
 @Service
 @RequiredArgsConstructor
 public class VoteRankingService {
 
-    private final VoteStat6hRepository voteStat6hRepository;
+//    private final VoteStat6hRepository voteStat6hRepository;
     private final VoteStatHourlyRepository voteStatHourlyRepository;
+    private final VoteRepository voteRepository;
 
     // 투표에 등록된 첫 이미지 썸네일 반환
     private String extractThumbnail(Vote vote) {
-        return vote.getImages().stream().findFirst()
-                .map(img -> img.getImageUrl()).orElse(null);
+        Optional<String> imageUrl = vote.getImages().stream()
+                .findFirst()
+                .map(VoteImage::getImageUrl); // Optional<String>
+
+        if (imageUrl.isPresent()) {
+            return imageUrl.get();
+        }
+
+        // 이미지가 없다면 옵션 이미지 중 첫 번째
+        return vote.getOptions().stream()
+                .map(VoteOption::getOptionImage)
+                .filter(img -> img != null && !img.isEmpty())
+                .findFirst()
+                .orElse(null); // 또는 기본 이미지 URL
     }
 
-    // 전체 득표순 정렬 (진행 중/종료 상태에 따라 분기)
+    // 총 투표수 기준 정렬
     public List<VoteSummaryDto> getVotesSortedByTotalVotes(VoteStatusType status, int page, int size) {
-        LocalDateTime now = LocalDateTime.now();
-        LocalDateTime latest = voteStat6hRepository.findLatestStatTime();
-        PageRequest pageable = PageRequest.of(page, size);
-
-        if (status == VoteStatusType.ONGOING) {
-            // 진행 중인 투표만
-            return voteStat6hRepository
-                    .findByStatTimeAndVote_FinishTimeAfterOrderByTotalVoteCountDesc(latest, now, pageable)
-                    .stream().map(this::toDto).toList();
-        } else if (status == VoteStatusType.ENDED) {
-            // 종료 된 투표만
-            return voteStat6hRepository
-                    .findByStatTimeAndVote_FinishTimeBeforeOrderByTotalVoteCountDesc(latest, now, pageable)
-                    .stream().map(this::toDto).toList();
-        } else {
-            // 전체 (전체)
-            return voteStat6hRepository
-                    .findByStatTimeOrderByTotalVoteCountDesc(latest, pageable)
-                    .stream().map(this::toDto).toList();
-        }
+        Pageable pageable = PageRequest.of(page, size);
+        List<Vote> sortedVotes = voteRepository.findVotesSortedByTotalVotes(status.name(), pageable);
+        return sortedVotes.stream().map(VoteSummaryDto::from).toList();
     }
 
-    // 오늘 득표순 정렬 (진행 중 투표만)
-    public List<VoteSummaryDto> getVotesSortedByTodayVotes(int page, int size) {
-        LocalDateTime now = LocalDateTime.now();
-        LocalDateTime latest = voteStat6hRepository.findLatestStatTime();
-        PageRequest pageable = PageRequest.of(page, size);
-
-        return voteStat6hRepository.findByStatTimeAndVote_FinishTimeAfterOrderByTodayVoteCountDesc(latest, now, pageable)
-                .stream().map(this::toDto).toList();
+    // 좋아요순 기준 정렬
+    public List<VoteSummaryDto> getVotesSortedByLikes(VoteStatusType status, int page, int size) {
+        Pageable pageable = PageRequest.of(page, size);
+        List<Vote> votes = voteRepository.findVotesSortedByLikes(status.name(), pageable);
+        return votes.stream().map(VoteSummaryDto::from).toList();
     }
 
-    // 댓글 수 기준 정렬 (진행 중/종료 상태에 따라 분기)
+    // 댓글수 기준 정렬
     public List<VoteSummaryDto> getVotesSortedByComments(VoteStatusType status, int page, int size) {
-        LocalDateTime now = LocalDateTime.now();
-        LocalDateTime latest = voteStat6hRepository.findLatestStatTime();
-        PageRequest pageable = PageRequest.of(page, size);
-
-        if (status == VoteStatusType.ONGOING) {
-            // 진행 중인 투표만
-            return voteStat6hRepository
-                    .findByStatTimeAndVote_FinishTimeAfterOrderByCommentCountDesc(latest, now, pageable)
-                    .stream().map(this::toDto).toList();
-        } else if (status == VoteStatusType.ENDED) {
-            // 종료 된 투표만
-            return voteStat6hRepository
-                    .findByStatTimeAndVote_FinishTimeBeforeOrderByCommentCountDesc(latest, now, pageable)
-                    .stream().map(this::toDto).toList();
-        } else {
-            // 전체
-            return voteStat6hRepository
-                    .findByStatTimeOrderByCommentCountDesc(latest, pageable)
-                    .stream().map(this::toDto).toList();
-        }
+        Pageable pageable = PageRequest.of(page, size);
+        List<Vote> votes = voteRepository.findVotesSortedByComments(status.name(), pageable);
+        return votes.stream().map(VoteSummaryDto::from).toList();
     }
+
+
+//    // 전체 득표순 정렬 (진행 중/종료 상태에 따라 분기)
+//    public List<VoteSummaryDto> getVotesSortedByTotalVotes(VoteStatusType status, int page, int size) {
+//        LocalDateTime now = LocalDateTime.now();
+//        LocalDateTime latest = voteStat6hRepository.findLatestStatTime();
+//        PageRequest pageable = PageRequest.of(page, size);
+//
+//        if (status == VoteStatusType.ONGOING) {
+//            // 진행 중인 투표만
+//            return voteStat6hRepository
+//                    .findByStatTimeAndVote_FinishTimeAfterOrderByTotalVoteCountDesc(latest, now, pageable)
+//                    .stream().map(this::toDto).toList();
+//        } else if (status == VoteStatusType.ENDED) {
+//            // 종료 된 투표만
+//            return voteStat6hRepository
+//                    .findByStatTimeAndVote_FinishTimeBeforeOrderByTotalVoteCountDesc(latest, now, pageable)
+//                    .stream().map(this::toDto).toList();
+//        } else {
+//            // 전체 (전체)
+//            return voteStat6hRepository
+//                    .findByStatTimeOrderByTotalVoteCountDesc(latest, pageable)
+//                    .stream().map(this::toDto).toList();
+//        }
+//    }
+//
+//    // 오늘 득표순 정렬 (진행 중 투표만)
+//    public List<VoteSummaryDto> getVotesSortedByTodayVotes(int page, int size) {
+//        LocalDateTime now = LocalDateTime.now();
+//        LocalDateTime latest = voteStat6hRepository.findLatestStatTime();
+//        PageRequest pageable = PageRequest.of(page, size);
+//
+//        return voteStat6hRepository.findByStatTimeAndVote_FinishTimeAfterOrderByTodayVoteCountDesc(latest, now, pageable)
+//                .stream().map(this::toDto).toList();
+//    }
+//
+//    // 댓글 수 기준 정렬 (진행 중/종료 상태에 따라 분기)
+//    public List<VoteSummaryDto> getVotesSortedByComments(VoteStatusType status, int page, int size) {
+//        LocalDateTime now = LocalDateTime.now();
+//        LocalDateTime latest = voteStat6hRepository.findLatestStatTime();
+//        PageRequest pageable = PageRequest.of(page, size);
+//
+//        if (status == VoteStatusType.ONGOING) {
+//            // 진행 중인 투표만
+//            return voteStat6hRepository
+//                    .findByStatTimeAndVote_FinishTimeAfterOrderByCommentCountDesc(latest, now, pageable)
+//                    .stream().map(this::toDto).toList();
+//        } else if (status == VoteStatusType.ENDED) {
+//            // 종료 된 투표만
+//            return voteStat6hRepository
+//                    .findByStatTimeAndVote_FinishTimeBeforeOrderByCommentCountDesc(latest, now, pageable)
+//                    .stream().map(this::toDto).toList();
+//        } else {
+//            // 전체
+//            return voteStat6hRepository
+//                    .findByStatTimeOrderByCommentCountDesc(latest, pageable)
+//                    .stream().map(this::toDto).toList();
+//        }
+//    }
 
     // 관심 급등순 정렬 (최근 1시간 투표 수 기준, 진행 중만)
     public List<TrendingVoteDto> getTrendingVotes(int page, int size) {
@@ -116,31 +157,31 @@ public class VoteRankingService {
                 }).toList();
     }
 
-    // VoteStat6h → VoteSummaryDto 매핑
-    private VoteSummaryDto toDto(VoteStat6h stat) {
-        Vote vote = stat.getVote();
-        return VoteSummaryDto.builder()
-                .voteId(vote.getVoteId())
-                .title(vote.getTitle())
-                .thumbnailImageUrl(extractThumbnail(vote))
-                .totalVotes(stat.getTotalVoteCount())
-                .todayVotes(stat.getTodayVoteCount())
-                .commentCount(stat.getCommentCount())
-                .rankTotal(stat.getRankTotal())
-                .rankToday(stat.getRankToday())
-                .rankComment(stat.getRankComment())
-                .rankChangeTotal(stat.getRankChangeTotal())
-                .rankChangeToday(stat.getRankChangeToday())
-                .rankChangeComment(stat.getRankChangeComment())
-                .ongoingCommentRank(stat.getOngoingCommentRank())
-                .ongoingCommentRankChange(stat.getOngoingCommentRankChange())
-                .ongoingVoteCountRank(stat.getOngoingVoteCountRank())
-                .ongoingVoteCountRankChange(stat.getOngoingVoteCountRankChange())
-                .endedCommentRank(stat.getEndedCommentRank())
-                .endedCommentRankChange(stat.getEndedCommentRankChange())
-                .endedVoteCountRank(stat.getEndedVoteCountRank())
-                .endedVoteCountRankChange(stat.getEndedVoteCountRankChange())
-                .finishTime(vote.getFinishTime())
-                .build();
-    }
+//    // VoteStat6h → VoteSummaryDto 매핑
+//    private VoteSummaryDto toDto(VoteStat6h stat) {
+//        Vote vote = stat.getVote();
+//        return VoteSummaryDto.builder()
+//                .voteId(vote.getVoteId())
+//                .title(vote.getTitle())
+//                .thumbnailImageUrl(extractThumbnail(vote))
+//                .totalVotes(stat.getTotalVoteCount())
+//                .todayVotes(stat.getTodayVoteCount())
+//                .commentCount(stat.getCommentCount())
+//                .rankTotal(stat.getRankTotal())
+//                .rankToday(stat.getRankToday())
+//                .rankComment(stat.getRankComment())
+//                .rankChangeTotal(stat.getRankChangeTotal())
+//                .rankChangeToday(stat.getRankChangeToday())
+//                .rankChangeComment(stat.getRankChangeComment())
+//                .ongoingCommentRank(stat.getOngoingCommentRank())
+//                .ongoingCommentRankChange(stat.getOngoingCommentRankChange())
+//                .ongoingVoteCountRank(stat.getOngoingVoteCountRank())
+//                .ongoingVoteCountRankChange(stat.getOngoingVoteCountRankChange())
+//                .endedCommentRank(stat.getEndedCommentRank())
+//                .endedCommentRankChange(stat.getEndedCommentRankChange())
+//                .endedVoteCountRank(stat.getEndedVoteCountRank())
+//                .endedVoteCountRankChange(stat.getEndedVoteCountRankChange())
+//                .finishTime(vote.getFinishTime())
+//                .build();
+//    }
 }

--- a/src/main/java/project/votebackend/type/VoteStatusType.java
+++ b/src/main/java/project/votebackend/type/VoteStatusType.java
@@ -2,5 +2,6 @@ package project.votebackend.type;
 
 public enum VoteStatusType {
     ONGOING,
-    ENDED
+    ENDED,
+    ALL
 }


### PR DESCRIPTION
### 📌 관련 이슈
- [054-vote-ranking]

### 🔍 작업 내용
- 기존 6시간 단위 스케줄링 기반 순위 저장 로직 제거
  - VoteStat6h 테이블을 통해 미리 계산해두던 순위 및 변화량 로직 제거
  - VoteSchedulingService.generate6hStats() 관련 로직 사용 중지
- 정렬 기준(총 투표수, 댓글 수, 좋아요 수) 변경 시 즉시 반영되도록 쿼리 기반 정렬 방식으로 전환
  - VoteRepository에서 JPQL 기반 정렬 쿼리 작성 (상태 필터링 포함)
  - 클라이언트 요청 시마다 최신 상태를 정렬하여 응답
- 자바에서 필터링하던 로직 제거, JPQL에서 상태(ALL, ONGOING, ENDED) 필터링 처리
  - 쿼리 결과 정확도 향상
  - 더 이상 stream().filter(...) 로직 사용하지 않음
- 순위 변화량(rankChange) 필드 등 제거 또는 미사용 처리


