### PR TITLE
feat: [003-follow-list] 타 유저의 팔로워, 팔로잉 목록 조회

### DIFF
--- a/src/main/java/project/votebackend/controller/follow/FollowController.java
+++ b/src/main/java/project/votebackend/controller/follow/FollowController.java
@@ -62,4 +62,18 @@ public class FollowController {
         Long myId = userDetails.getId();
         return ResponseEntity.ok(followListService.getFollowings(myId));
     }
+
+    // 특정 사용자의 팔로워 목록 조회
+    @GetMapping("/{userId}/followers")
+    public ResponseEntity<List<FollowUserDto>> getUserFollowers(@PathVariable Long userId,
+                                                                @AuthenticationPrincipal CustumUserDetails userDetails) {
+        return ResponseEntity.ok(followListService.getFollowersOfUser(userId, userDetails.getId()));
+    }
+
+    // 특정 사용자의 팔로잉 목록 조회
+    @GetMapping("/{userId}/followings")
+    public ResponseEntity<List<FollowUserDto>> getUserFollowings(@PathVariable Long userId,
+                                                                 @AuthenticationPrincipal CustumUserDetails userDetails) {
+        return ResponseEntity.ok(followListService.getFollowingsOfUser(userId, userDetails.getId()));
+    }
 }


### PR DESCRIPTION
📌 관련 이슈
- [003-follow-list]

🔍 작업 내용
- 특정 사용자의 팔로워 및 팔로잉 목록을 조회할 수 있는 API를 추가
  - GET /api/follow/{userId}/followers
  - GET /api/follow/{userId}/followings
- 로그인한 사용자가 각 유저에 대해 팔로우 여부(isFollowing)를 확인할 수 있도록 처리
- 기존 getMyFollowers, getMyFollowings 구조를 재활용하여 재사용성 확보