### PR TITLE
fix: [018-vote-storage] 저장고 투표 dto수정

### DIFF
--- a/src/main/java/project/votebackend/controller/storage/StorageController.java
+++ b/src/main/java/project/votebackend/controller/storage/StorageController.java
@@ -9,10 +9,12 @@ import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+import project.votebackend.dto.vote.VoteSummaryDto;
 import project.votebackend.security.CustumUserDetails;
 import project.votebackend.service.storage.StorageService;
 import project.votebackend.util.PageResponseUtil;
 
+import java.util.List;
 import java.util.Map;
 
 @RestController
@@ -24,28 +26,55 @@ public class StorageController {
 
     //투표한 게시물 불러오기
     @GetMapping("/voted")
-    public ResponseEntity<Map<String, Object>> getVotedPosts(
+    public List<VoteSummaryDto> getVotedPosts(
             @AuthenticationPrincipal CustumUserDetails userDetails,
             @PageableDefault(size = 10, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable
     ) {
-        return ResponseEntity.ok(PageResponseUtil.toResponse(storageService.getVotedPosts(userDetails.getId(), pageable)));
+        return storageService.getVotedPosts(userDetails.getId(), pageable);
     }
 
     //북마크한 게시물 불러오기
     @GetMapping("/bookmarked")
-    public ResponseEntity<Map<String, Object>> getBookmarkedPosts(
+    public List<VoteSummaryDto> getBookmarkedPosts(
             @AuthenticationPrincipal CustumUserDetails userDetails,
             @PageableDefault(size = 10, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable
     ) {
-        return ResponseEntity.ok(PageResponseUtil.toResponse(storageService.getBookmarkedPosts(userDetails.getId(), pageable)));
+        return storageService.getBookmarkedPosts(userDetails.getId(), pageable);
     }
 
     //내가 작성한 게시물 불러오기
     @GetMapping("/created")
-    public ResponseEntity<Map<String, Object>> getCreatedPosts(
+    public List<VoteSummaryDto> getCreatedPosts(
             @AuthenticationPrincipal CustumUserDetails userDetails,
             @PageableDefault(size = 10, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable
     ) {
-        return ResponseEntity.ok(PageResponseUtil.toResponse(storageService.getCreatedPosts(userDetails.getId(), pageable)));
+        return storageService.getCreatedPosts(userDetails.getId(), pageable);
     }
+
+//    //투표한 게시물 불러오기
+//    @GetMapping("/voted")
+//    public ResponseEntity<Map<String, Object>> getVotedPosts(
+//            @AuthenticationPrincipal CustumUserDetails userDetails,
+//            @PageableDefault(size = 10, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable
+//    ) {
+//        return ResponseEntity.ok(PageResponseUtil.toResponse(storageService.getVotedPosts(userDetails.getId(), pageable)));
+//    }
+//
+//    //북마크한 게시물 불러오기
+//    @GetMapping("/bookmarked")
+//    public ResponseEntity<Map<String, Object>> getBookmarkedPosts(
+//            @AuthenticationPrincipal CustumUserDetails userDetails,
+//            @PageableDefault(size = 10, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable
+//    ) {
+//        return ResponseEntity.ok(PageResponseUtil.toResponse(storageService.getBookmarkedPosts(userDetails.getId(), pageable)));
+//    }
+//
+//    //내가 작성한 게시물 불러오기
+//    @GetMapping("/created")
+//    public ResponseEntity<Map<String, Object>> getCreatedPosts(
+//            @AuthenticationPrincipal CustumUserDetails userDetails,
+//            @PageableDefault(size = 10, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable
+//    ) {
+//        return ResponseEntity.ok(PageResponseUtil.toResponse(storageService.getCreatedPosts(userDetails.getId(), pageable)));
+//    }
 }

--- a/src/main/java/project/votebackend/service/storage/StorageService.java
+++ b/src/main/java/project/votebackend/service/storage/StorageService.java
@@ -6,6 +6,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import project.votebackend.domain.vote.Vote;
 import project.votebackend.dto.vote.LoadVoteDto;
+import project.votebackend.dto.vote.VoteSummaryDto;
 import project.votebackend.repository.vote.VoteRepository;
 import project.votebackend.util.VoteStatisticsUtil;
 
@@ -19,28 +20,51 @@ public class StorageService {
     private final VoteRepository voteRepository;
     private final VoteStatisticsUtil voteStatisticsUtil;
 
-
-    //내가 투표한 게시물
-    public Page<LoadVoteDto> getVotedPosts(Long userId, Pageable pageable) {
+    //참여한 게시물
+    public List<VoteSummaryDto> getVotedPosts(Long userId, Pageable pageable) {
         Page<Vote> votes = voteRepository.findVotedByUserId(userId, pageable);
-        List<Long> voteIds = votes.getContent().stream().map(Vote::getVoteId).toList();
-        Map<String, Object> stats = voteStatisticsUtil.collectVoteStatistics(userId, voteIds);
-        return voteStatisticsUtil.getLoadVoteDtos(userId, votes, stats, pageable);
+        return votes.stream()
+                .map(VoteSummaryDto::from)
+                .toList();
     }
 
     //북마크한 게시물
-    public Page<LoadVoteDto> getBookmarkedPosts(Long userId, Pageable pageable) {
+    public List<VoteSummaryDto> getBookmarkedPosts(Long userId, Pageable pageable) {
         Page<Vote> votes = voteRepository.findBookmarkedVotes(userId, pageable);
-        List<Long> voteIds = votes.getContent().stream().map(Vote::getVoteId).toList();
-        Map<String, Object> stats = voteStatisticsUtil.collectVoteStatistics(userId, voteIds);
-        return voteStatisticsUtil.getLoadVoteDtos(userId, votes, stats, pageable);
+        return votes.stream()
+                .map(VoteSummaryDto::from)
+                .toList();
     }
 
     //내가 작성한 게시물
-    public Page<LoadVoteDto> getCreatedPosts(Long userId, Pageable pageable) {
+    public List<VoteSummaryDto> getCreatedPosts(Long userId, Pageable pageable) {
         Page<Vote> votes = voteRepository.findByUser_UserId(userId, pageable);
-        List<Long> voteIds = votes.getContent().stream().map(Vote::getVoteId).toList();
-        Map<String, Object> stats = voteStatisticsUtil.collectVoteStatistics(userId, voteIds);
-        return voteStatisticsUtil.getLoadVoteDtos(userId, votes, stats, pageable);
+        return votes.stream()
+                .map(VoteSummaryDto::from)
+                .toList();
     }
+
+//    //내가 투표한 게시물
+//    public Page<LoadVoteDto> getVotedPosts(Long userId, Pageable pageable) {
+//        Page<Vote> votes = voteRepository.findVotedByUserId(userId, pageable);
+//        List<Long> voteIds = votes.getContent().stream().map(Vote::getVoteId).toList();
+//        Map<String, Object> stats = voteStatisticsUtil.collectVoteStatistics(userId, voteIds);
+//        return voteStatisticsUtil.getLoadVoteDtos(userId, votes, stats, pageable);
+//    }
+//
+//    //북마크한 게시물
+//    public Page<LoadVoteDto> getBookmarkedPosts(Long userId, Pageable pageable) {
+//        Page<Vote> votes = voteRepository.findBookmarkedVotes(userId, pageable);
+//        List<Long> voteIds = votes.getContent().stream().map(Vote::getVoteId).toList();
+//        Map<String, Object> stats = voteStatisticsUtil.collectVoteStatistics(userId, voteIds);
+//        return voteStatisticsUtil.getLoadVoteDtos(userId, votes, stats, pageable);
+//    }
+//
+//    //내가 작성한 게시물
+//    public Page<LoadVoteDto> getCreatedPosts(Long userId, Pageable pageable) {
+//        Page<Vote> votes = voteRepository.findByUser_UserId(userId, pageable);
+//        List<Long> voteIds = votes.getContent().stream().map(Vote::getVoteId).toList();
+//        Map<String, Object> stats = voteStatisticsUtil.collectVoteStatistics(userId, voteIds);
+//        return voteStatisticsUtil.getLoadVoteDtos(userId, votes, stats, pageable);
+//    }
 }


### PR DESCRIPTION
### 📌 관련 이슈
- [018-vote-storage]

### 🔍 작업 내용
1. `/storage/voted`, `/storage/bookmarked`, `/storage/created` 엔드포인트의 반환값을 `Page<LoadVoteDto>` → `List<VoteSummaryDto>`로 수정
2. 프론트엔드에서 요약 정보만 필요하기 때문에, 간단한 응답 구조로 변경
3. `VoteSummaryDto.from()`을 활용하여 title, 투표 수, 좋아요 수, 댓글 수 등 요약 정보를 구성

