### PR TITLE
fix: [031-user-profile] 다른 유저 조회 투표 dto 수정

### DIFF
--- a/src/main/java/project/votebackend/dto/user/OtherUserPageDto.java
+++ b/src/main/java/project/votebackend/dto/user/OtherUserPageDto.java
@@ -4,6 +4,7 @@ import lombok.Builder;
 import lombok.Data;
 import org.springframework.data.domain.Page;
 import project.votebackend.dto.vote.LoadVoteDto;
+import project.votebackend.dto.vote.OtherUserVotes;
 import project.votebackend.type.Grade;
 
 import java.time.LocalDateTime;
@@ -25,5 +26,5 @@ public class OtherUserPageDto {
     private Long postCount;
     private Long participatedCount;
     private LocalDateTime createdAt;
-    private Page<LoadVoteDto> posts;
+    private Page<OtherUserVotes> posts;
 }

--- a/src/main/java/project/votebackend/dto/vote/OtherUserVotes.java
+++ b/src/main/java/project/votebackend/dto/vote/OtherUserVotes.java
@@ -1,0 +1,53 @@
+package project.votebackend.dto.vote;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import project.votebackend.domain.vote.Vote;
+import project.votebackend.domain.vote.VoteImage;
+import project.votebackend.domain.vote.VoteOption;
+
+import java.util.List;
+import java.util.Optional;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class OtherUserVotes {
+    private Long voteId;
+    private String title;
+    private String thumbnailUrl;
+
+    public static Page<OtherUserVotes> otherUserVotes(Page<Vote> votes, Pageable pageable) {
+        List<OtherUserVotes> content = votes.getContent().stream()
+                .map(vote -> OtherUserVotes.builder()
+                        .voteId(vote.getVoteId())
+                        .title(vote.getTitle())
+                        .thumbnailUrl(extractThumbnail(vote))
+                        .build())
+                .toList();
+
+        return new PageImpl<>(content, pageable, votes.getTotalElements());
+    }
+
+    private static String extractThumbnail(Vote vote) {
+        Optional<String> imageUrl = vote.getImages().stream()
+                .findFirst()
+                .map(VoteImage::getImageUrl);
+
+        if (imageUrl.isPresent()) {
+            return imageUrl.get();
+        }
+
+        return vote.getOptions().stream()
+                .map(VoteOption::getOptionImage)
+                .filter(img -> img != null && !img.isEmpty())
+                .findFirst()
+                .orElse(null);
+    }
+}

--- a/src/main/java/project/votebackend/service/user/UserService.java
+++ b/src/main/java/project/votebackend/service/user/UserService.java
@@ -15,6 +15,7 @@ import project.votebackend.domain.user.UserInterest;
 import project.votebackend.domain.vote.Vote;
 import project.votebackend.dto.user.*;
 import project.votebackend.dto.vote.LoadVoteDto;
+import project.votebackend.dto.vote.OtherUserVotes;
 import project.votebackend.elasticSearch.UserDocument;
 import project.votebackend.exception.AuthException;
 import project.votebackend.exception.CategoryException;
@@ -100,13 +101,9 @@ public class UserService {
 
         // 3. 해당 사용자의 투표글 조회
         Page<Vote> votes = voteRepository.findByUser_UserIdAndStatus(userId, VoteStatus.PUBLISHED, sortedPageable);
-        List<Long> voteIds = votes.getContent().stream()
-                .map(Vote::getVoteId)
-                .toList();
 
-        // 4. 통계 수집 및 DTO 변환
-        Map<String, Object> stats = voteStatisticsUtil.collectVoteStatistics(userId, voteIds);
-        Page<LoadVoteDto> voteDto = voteStatisticsUtil.getLoadVoteDtos(userId, votes, stats, sortedPageable);
+        // 4. DTO 변환
+        Page<OtherUserVotes> voteDto = OtherUserVotes.otherUserVotes(votes, sortedPageable);
 
         // 5. 게시글 수, 팔로워 수, 팔로잉 수 계산
         Long postCount = voteRepository.countByUser_UserId(userId);


### PR DESCRIPTION
### 📌 관련 이슈
- [031-user-profile]

### 🔍 작업 내용
1. 기존에 다른 사용자 페이지에서 전체 투표 데이터를 `LoadVoteDto`로 내려주던 구조를, 간단한 정보(`title`, `thumbnailUrl`)만 포함하는 `OtherUserVotes`로 변경
2. `OtherUserVotes` 변환 메서드를 `static Page<OtherUserVotes> otherUserVotes(Page<Vote> votes, Pageable pageable)` 형태로 통일
3. `OtherUserPageDto`의 `posts` 필드 타입을 `Page<OtherUserVotes>`로 유지하고 정렬 및 페이징이 잘 동작하도록 수정
