### PR TITLE
feat: [064-temporary-storage] 임시저장글 조회

### DIFF
--- a/src/main/java/project/votebackend/controller/storage/StorageController.java
+++ b/src/main/java/project/votebackend/controller/storage/StorageController.java
@@ -55,30 +55,12 @@ public class StorageController {
         return storageService.getCreatedPosts(userDetails.getId(), pageable);
     }
 
-//    //투표한 게시물 불러오기
-//    @GetMapping("/voted")
-//    public ResponseEntity<Map<String, Object>> getVotedPosts(
-//            @AuthenticationPrincipal CustumUserDetails userDetails,
-//            @PageableDefault(size = 10, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable
-//    ) {
-//        return ResponseEntity.ok(PageResponseUtil.toResponse(storageService.getVotedPosts(userDetails.getId(), pageable)));
-//    }
-//
-//    //북마크한 게시물 불러오기
-//    @GetMapping("/bookmarked")
-//    public ResponseEntity<Map<String, Object>> getBookmarkedPosts(
-//            @AuthenticationPrincipal CustumUserDetails userDetails,
-//            @PageableDefault(size = 10, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable
-//    ) {
-//        return ResponseEntity.ok(PageResponseUtil.toResponse(storageService.getBookmarkedPosts(userDetails.getId(), pageable)));
-//    }
-//
-//    //내가 작성한 게시물 불러오기
-//    @GetMapping("/created")
-//    public ResponseEntity<Map<String, Object>> getCreatedPosts(
-//            @AuthenticationPrincipal CustumUserDetails userDetails,
-//            @PageableDefault(size = 10, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable
-//    ) {
-//        return ResponseEntity.ok(PageResponseUtil.toResponse(storageService.getCreatedPosts(userDetails.getId(), pageable)));
-//    }
+    @GetMapping("/drafts")
+    @Operation(summary = "임시 저장한 게시물 조회 API", description = "내가 임시 저장한 게시물(DRAFT 상태)을 조회합니다.")
+    public List<VoteSummaryDto> getDraftPosts(
+            @AuthenticationPrincipal CustumUserDetails userDetails,
+            @PageableDefault(size = 10, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable
+    ) {
+        return storageService.getDraftPosts(userDetails.getId(), pageable);
+    }
 }

--- a/src/main/java/project/votebackend/repository/vote/VoteRepository.java
+++ b/src/main/java/project/votebackend/repository/vote/VoteRepository.java
@@ -53,18 +53,6 @@ public interface VoteRepository extends JpaRepository<Vote, Long> {
             @Param("limit") int limit,
             @Param("offset") int offset
     );
-// 마감된글, 이미 투표한글은 제외
-//    SELECT v FROM Vote v
-//    WHERE (v.user.userId = :userId
-//                    OR v.category.categoryId IN :categoryIds
-//                    OR v.user.userId IN (
-//                    SELECT f.followingId FROM Follow f WHERE f.followerId = :userId
-//            ))
-//    AND v.voteId NOT IN (
-//            SELECT vs.vote.voteId FROM VoteSelection vs WHERE vs.user.userId = :userId
-//    )
-//    AND v.finishTime > CURRENT_TIMESTAMP
-//    ORDER BY v.createdAt DESC
 
     //메인페이지 글 개수 count
     @Query(value = """

--- a/src/main/java/project/votebackend/service/storage/StorageService.java
+++ b/src/main/java/project/votebackend/service/storage/StorageService.java
@@ -8,6 +8,7 @@ import project.votebackend.domain.vote.Vote;
 import project.votebackend.dto.vote.LoadVoteDto;
 import project.votebackend.dto.vote.VoteSummaryDto;
 import project.votebackend.repository.vote.VoteRepository;
+import project.votebackend.type.VoteStatus;
 import project.votebackend.util.VoteStatisticsUtil;
 
 import java.util.List;
@@ -39,6 +40,14 @@ public class StorageService {
     //내가 작성한 게시물
     public List<VoteSummaryDto> getCreatedPosts(Long userId, Pageable pageable) {
         Page<Vote> votes = voteRepository.findByUser_UserId(userId, pageable);
+        return votes.stream()
+                .map(VoteSummaryDto::from)
+                .toList();
+    }
+
+    //내가 임시저장한 게시물
+    public List<VoteSummaryDto> getDraftPosts(Long userId, Pageable pageable) {
+        Page<Vote> votes = voteRepository.findByUser_UserIdAndStatus(userId, VoteStatus.DRAFT, pageable);
         return votes.stream()
                 .map(VoteSummaryDto::from)
                 .toList();


### PR DESCRIPTION
📌 관련 이슈
- [064-temporary-storage]

🔍 작업 내용
- 임시저장 상태의 게시물만 조회하는 API 추가
- `storageService.getDraftPosts()` 서비스 메서드 구현
- `/storage/drafts` GET API 추가
- 임시 저장 글만 필터링한 이유
  - 사용자가 작성 도중 저장한 글(DRAFT)을 별도로 보여줄 필요가 있었음
  - 기존 `/created` API는 전체 글을 조회하여 구분이 어려웠음