### PR TITLE
feat: [062-get-news] 생성된 뉴스 저장

### DIFF
--- a/src/main/java/project/votebackend/application/article/ClusterIngestMapper.java
+++ b/src/main/java/project/votebackend/application/article/ClusterIngestMapper.java
@@ -1,0 +1,41 @@
+package project.votebackend.application.article;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import project.votebackend.domain.article.Article;
+import project.votebackend.domain.article.Cluster;
+import project.votebackend.dto.article.IngestArticleDto;
+import project.votebackend.dto.article.IngestClusterNode;
+
+@Component
+@RequiredArgsConstructor
+public class ClusterIngestMapper {
+
+    public void fillClusterFromNode(Cluster cluster, IngestClusterNode node) {
+        cluster.setImageUrl(node.getImageUrl());
+        cluster.setTitle(node.getTitle());
+        cluster.setSourceArticleUrl(node.getSourceArticleUrl());
+        cluster.setSourceOriginalArticleUrl(node.getSourceOriginalArticleUrl());
+
+        cluster.setSubtitle1(node.getSubtitle1());
+        cluster.setSubtitle2(node.getSubtitle2());
+        cluster.setSubtitle3(node.getSubtitle3());
+        cluster.setSubtitle4(node.getSubtitle4());
+
+        cluster.setContent1(node.getContent1());
+        cluster.setContent2(node.getContent2());
+        cluster.setContent3(node.getContent3());
+        cluster.setContent4(node.getContent4());
+    }
+
+    public Article toArticleEntity(IngestArticleDto dto, Cluster cluster) {
+        Article a = new Article();
+        a.setCluster(cluster);
+        a.setUrl(dto.getUrl());
+        a.setOriginalUrl(dto.getOriginalUrl());
+        a.setTitle(dto.getTitle());
+        a.setPublisher(dto.getPublisher());
+        a.setPublishedAt(dto.getPublishedAt());
+        return a;
+    }
+}

--- a/src/main/java/project/votebackend/config/RestTemplateConfig.java
+++ b/src/main/java/project/votebackend/config/RestTemplateConfig.java
@@ -1,0 +1,14 @@
+package project.votebackend.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.client.RestTemplate;
+
+@Configuration
+public class RestTemplateConfig {
+
+    @Bean
+    public RestTemplate restTemplate() {
+        return new RestTemplate();
+    }
+}

--- a/src/main/java/project/votebackend/config/SecurityConfig.java
+++ b/src/main/java/project/votebackend/config/SecurityConfig.java
@@ -35,7 +35,7 @@ public class SecurityConfig {
                 .authorizeHttpRequests(auth -> auth
                         // 로그인, 회원가입, 공유 등의 인증 없이 접근 가능한 엔드포인트
                         .requestMatchers("/location/verify","/auth/**", "/image/upload", "/share/vote/**",
-                                "/email/**", "/result/**").permitAll()
+                                "/email/**", "/result/**", "/ingest/**").permitAll()
 
                         // 댓글 조회만 허용
                         .requestMatchers(HttpMethod.GET, "/comment/**").permitAll()

--- a/src/main/java/project/votebackend/controller/article/ClusterIngestController.java
+++ b/src/main/java/project/votebackend/controller/article/ClusterIngestController.java
@@ -1,0 +1,30 @@
+package project.votebackend.controller.article;
+
+import io.swagger.v3.oas.annotations.Operation;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import project.votebackend.dto.article.IngestPayload;
+import project.votebackend.service.article.ClusterIngestService;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/ingest")
+public class ClusterIngestController {
+
+    private final ClusterIngestService ingestService;
+
+    @GetMapping
+    @Operation(summary = "뉴스 생성 API", description = "AI와 연동하여 생성된 뉴스 기사를 받아옵니다.")
+    public ResponseEntity<String> ingestFromExternal(@RequestParam("source") String sourceUrl) {
+        ingestService.ingestFromUrl(sourceUrl);
+        return ResponseEntity.ok("OK");
+    }
+
+    @PostMapping
+    @Operation(summary = "JSON 파싱 테스트 API", description = "JSON 파일의 파싱 과정을 검증하기 위한 API입니다.")
+    public ResponseEntity<String> ingestFromBody(@RequestBody IngestPayload payload) {
+        ingestService.ingest(payload);
+        return ResponseEntity.ok("OK");
+    }
+}

--- a/src/main/java/project/votebackend/domain/article/Article.java
+++ b/src/main/java/project/votebackend/domain/article/Article.java
@@ -2,32 +2,40 @@ package project.votebackend.domain.article;
 
 import jakarta.persistence.*;
 import lombok.*;
+import project.votebackend.domain.BaseEntity;
 
 import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
 
 @Entity
-@Table(name = "cluster")
+@Table(name = "article")
 @Getter
 @Setter
 @NoArgsConstructor
 @AllArgsConstructor
-public class Article {
+public class Article extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "article_id")
     private Long id;
 
-    @Column(length = 500)
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "cluster_id")
+    private Cluster cluster;
+
+    @Column
     private String url;
 
-    @Column(length = 500)
+    @Column
+    private String originalUrl;
+
+    @Column
     private String title;
 
+    @Column
     private String publisher;
 
+    @Column
     private LocalDateTime publishedAt;
-
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "cluster_id", nullable = false)
-    private Cluster cluster;
 }

--- a/src/main/java/project/votebackend/domain/article/Cluster.java
+++ b/src/main/java/project/votebackend/domain/article/Cluster.java
@@ -5,6 +5,7 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+import project.votebackend.domain.BaseEntity;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -15,37 +16,49 @@ import java.util.List;
 @Setter
 @NoArgsConstructor
 @AllArgsConstructor
-public class Cluster {
+public class Cluster extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "cluster_id")
     private Long id;
 
-    @Column(length = 500)
+    @Column
     private String imageUrl;
 
-    @Column(length = 500)
+    @Column
+    private String sourceArticleUrl;
+
+    @Column
+    private String sourceOriginalArticleUrl;
+
+    @Column
     private String title;
 
-    @Column(columnDefinition = "TEXT")
-    private String subtitle1;
-
-    @Column(columnDefinition = "TEXT")
-    private String subtitle2;
-
-    @Column(columnDefinition = "TEXT")
-    private String subtitle3;
-
-    @Column(columnDefinition = "TEXT")
+    @Column
     private String content1;
 
-    @Column(columnDefinition = "TEXT")
+    @Column
     private String content2;
 
-    @Column(columnDefinition = "TEXT")
+    @Column
     private String content3;
+
+    @Column
+    private String content4;
+
+    @Column
+    private String subtitle1;
+
+    @Column
+    private String subtitle2;
+
+    @Column
+    private String subtitle3;
+
+    @Column
+    private String subtitle4;
 
     @OneToMany(mappedBy = "cluster", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<Article> articles = new ArrayList<>();
-
 }

--- a/src/main/java/project/votebackend/dto/article/IngestArticleDto.java
+++ b/src/main/java/project/votebackend/dto/article/IngestArticleDto.java
@@ -1,0 +1,23 @@
+package project.votebackend.dto.article;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+public class IngestArticleDto {
+
+    private String url;
+
+    @JsonProperty("original_url")
+    private String originalUrl;
+
+    private String title;
+    private String publisher;
+
+    @JsonProperty("published_at")
+    @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
+    private LocalDateTime publishedAt;
+}

--- a/src/main/java/project/votebackend/dto/article/IngestClusterNode.java
+++ b/src/main/java/project/votebackend/dto/article/IngestClusterNode.java
@@ -1,0 +1,36 @@
+package project.votebackend.dto.article;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+public class IngestClusterNode {
+
+    @JsonProperty("cluster_id")
+    private String clusterId;
+
+    private List<IngestArticleDto> articles;
+
+    @JsonProperty("source_article_url")
+    private String sourceArticleUrl;
+
+    @JsonProperty("source_original_article_url")
+    private String sourceOriginalArticleUrl;
+
+    @JsonProperty("image_url")
+    private String imageUrl;
+
+    private String title;
+
+    private String subtitle1;
+    private String subtitle2;
+    private String subtitle3;
+    private String subtitle4;
+
+    private String content1;
+    private String content2;
+    private String content3;
+    private String content4;
+}

--- a/src/main/java/project/votebackend/dto/article/IngestPayload.java
+++ b/src/main/java/project/votebackend/dto/article/IngestPayload.java
@@ -1,0 +1,18 @@
+package project.votebackend.dto.article;
+
+import com.fasterxml.jackson.annotation.JsonAnySetter;
+import lombok.Getter;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@Getter
+public class IngestPayload {
+
+    private final Map<String, IngestClusterNode> clusters = new HashMap<>();
+
+    @JsonAnySetter
+    public void put(String key, IngestClusterNode value) {
+        clusters.put(key, value);
+    }
+}

--- a/src/main/java/project/votebackend/repository/article/ArticleRepository.java
+++ b/src/main/java/project/votebackend/repository/article/ArticleRepository.java
@@ -1,0 +1,16 @@
+package project.votebackend.repository.article;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+import project.votebackend.domain.article.Article;
+
+import java.util.Optional;
+
+@Repository
+public interface ArticleRepository extends JpaRepository<Article, Long> {
+
+    @Query("SELECT a FROM Article a WHERE a.cluster.id = :clusterId AND a.url = :url")
+    Optional<Article> findByClusterIdAndUrl(@Param("clusterId") Long clusterId, @Param("url") String url);
+}

--- a/src/main/java/project/votebackend/repository/article/ClusterRepository.java
+++ b/src/main/java/project/votebackend/repository/article/ClusterRepository.java
@@ -1,0 +1,14 @@
+package project.votebackend.repository.article;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+import project.votebackend.domain.article.Cluster;
+
+import java.util.Optional;
+
+@Repository
+public interface ClusterRepository extends JpaRepository<Cluster, Long> {
+
+    Optional<Cluster> findByTitle(String title);
+
+}

--- a/src/main/java/project/votebackend/service/article/ClusterIngestService.java
+++ b/src/main/java/project/votebackend/service/article/ClusterIngestService.java
@@ -1,0 +1,60 @@
+package project.votebackend.service.article;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.client.RestTemplate;
+import project.votebackend.application.article.ClusterIngestMapper;
+import project.votebackend.domain.article.Article;
+import project.votebackend.domain.article.Cluster;
+import project.votebackend.dto.article.IngestArticleDto;
+import project.votebackend.dto.article.IngestClusterNode;
+import project.votebackend.dto.article.IngestPayload;
+import project.votebackend.repository.article.ArticleRepository;
+import project.votebackend.repository.article.ClusterRepository;
+
+@Service
+@RequiredArgsConstructor
+public class ClusterIngestService {
+
+    private final RestTemplate restTemplate;
+    private final ClusterRepository clusterRepository;
+    private final ArticleRepository articleRepository;
+    private final ClusterIngestMapper mapper;
+
+    public void ingestFromUrl(String sourceUrl) {
+        // 외부 API 호출 → Json을 자가 객체로 역직렬화
+        IngestPayload payload = restTemplate.getForObject(sourceUrl, IngestPayload.class);
+
+        if (payload != null) {
+            ingest(payload);
+        }
+    }
+
+    // 역직렬화 한 데이터를 DB에 저장
+    @Transactional
+    public void ingest(IngestPayload payload) {
+        payload.getClusters().forEach((key, node) -> upsertOneCluster(node));
+    }
+
+    private void upsertOneCluster(IngestClusterNode node) {
+        Cluster cluster = clusterRepository.findByTitle(node.getTitle())
+                .orElseGet(Cluster::new);
+
+        mapper.fillClusterFromNode(cluster, node);
+        Cluster saved = clusterRepository.save(cluster);
+
+        if (node.getArticles() != null) {
+            for (IngestArticleDto aDto : node.getArticles()) {
+                boolean exists = articleRepository
+                        .findByClusterIdAndUrl(saved.getId(), aDto.getUrl())
+                        .isPresent();
+
+                if (!exists) {
+                    Article article = mapper.toArticleEntity(aDto, saved);
+                    articleRepository.save(article);
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
📌 관련 이슈
- [062-get-news]

🔍 작업 내용
- 뉴스 클러스터/아티클 일괄 수집 파이프라인 구축
  - `ClusterIngestController`에 GET `/ingest`(외부 JSON URL 인입) & POST `/ingest`(본문 JSON 인입) 2가지 엔드포인트 추가.
  - `ClusterIngestService`에서 `RestTemplate`으로 JSON을 받아 `IngestPayload`로 역직렬화 후 DB 저장까지 트랜잭션 처리.
  - `ClusterIngestMapper`로 DTO → 엔티티 매핑(클러스터 정보 채움, 아티클 변환).
- 중복 저장 방지 로직 도입
  - `ArticleRepository#findByClusterIdAndUrl`로 클러스터-URL 단위 중복 검사 후 신규만 insert.
- Mapper
  - `fillClusterFromNode` 클러스터 메타 필드 매핑.
  - `toArticleEntity` 기사 DTO → 엔티티 변환.