### PR TITLE
feat: [062-get-news] 생성된 뉴스 조회

### DIFF
--- a/src/main/java/project/votebackend/config/SecurityConfig.java
+++ b/src/main/java/project/votebackend/config/SecurityConfig.java
@@ -61,7 +61,8 @@ public class SecurityConfig {
                                 "/comment-like/**",  // 댓글 좋아요
                                 "/search/**",        // 검색
                                 "/follow/**",         // 팔로우
-                                "/rank/**"            // 랭킹
+                                "/rank/**",            // 랭킹
+                                "/cluster/**"          // 생성된 뉴스
                         ).authenticated()
 
                         // 그 외 요청은 모두 허용

--- a/src/main/java/project/votebackend/controller/article/ClusterController.java
+++ b/src/main/java/project/votebackend/controller/article/ClusterController.java
@@ -1,15 +1,14 @@
 package project.votebackend.controller.article;
 
+import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
+import project.votebackend.dto.article.ClusterDetailDto;
 import project.votebackend.dto.article.ClusterSummaryDto;
 import project.votebackend.service.article.ClusterService;
 import project.votebackend.util.PageResponseUtil;
@@ -23,7 +22,10 @@ public class ClusterController {
 
     private final ClusterService clusterService;
 
+    // 뉴스 목록 조회
     @GetMapping
+    @Operation(summary = "뉴스 목록 조회 API", description = "생성된 뉴스들을 조회합니다.")
+
     public ResponseEntity<Map<String, Object>> loadMainPageClusters(
             @RequestParam(defaultValue = "0") int page,
             @RequestParam(defaultValue = "10") int size
@@ -32,4 +34,12 @@ public class ClusterController {
         Page<ClusterSummaryDto> clusterPage = clusterService.getMainPageClusters(pageable);
         return ResponseEntity.ok(PageResponseUtil.toResponse(clusterPage));
     }
+
+    // 상세 조회
+    @GetMapping("/{clusterId}")
+    @Operation(summary = "뉴스 상세 조회 API", description = "뉴스를 상세조회 합니다.")
+    public ResponseEntity<ClusterDetailDto> getClusterDetail(@PathVariable Long clusterId) {
+        return ResponseEntity.ok(clusterService.getClusterDetail(clusterId));
+    }
+
 }

--- a/src/main/java/project/votebackend/controller/article/ClusterController.java
+++ b/src/main/java/project/votebackend/controller/article/ClusterController.java
@@ -1,0 +1,35 @@
+package project.votebackend.controller.article;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import project.votebackend.dto.article.ClusterSummaryDto;
+import project.votebackend.service.article.ClusterService;
+import project.votebackend.util.PageResponseUtil;
+
+import java.util.Map;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/cluster")
+public class ClusterController {
+
+    private final ClusterService clusterService;
+
+    @GetMapping
+    public ResponseEntity<Map<String, Object>> loadMainPageClusters(
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "10") int size
+    ) {
+        Pageable pageable = PageRequest.of(page, size, Sort.by("createdAt").descending());
+        Page<ClusterSummaryDto> clusterPage = clusterService.getMainPageClusters(pageable);
+        return ResponseEntity.ok(PageResponseUtil.toResponse(clusterPage));
+    }
+}

--- a/src/main/java/project/votebackend/dto/article/ArticleItemDto.java
+++ b/src/main/java/project/votebackend/dto/article/ArticleItemDto.java
@@ -1,0 +1,16 @@
+package project.votebackend.dto.article;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@AllArgsConstructor
+@Getter
+public class ArticleItemDto {
+    private String url;
+    private String originalUrl;
+    private String title;
+    private String publisher;
+    private LocalDateTime publishedAt;
+}

--- a/src/main/java/project/votebackend/dto/article/ClusterDetailDto.java
+++ b/src/main/java/project/votebackend/dto/article/ClusterDetailDto.java
@@ -1,0 +1,29 @@
+package project.votebackend.dto.article;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Getter
+@AllArgsConstructor
+public class ClusterDetailDto {
+    private Long clusterId;
+    private String imageUrl;
+    private String title;
+    private LocalDateTime createdAt;
+
+    private String subtitle1;
+    private String subtitle2;
+    private String subtitle3;
+    private String subtitle4;
+
+    private String content1;
+    private String content2;
+    private String content3;
+    private String content4;
+
+    // 출처 기사
+    private List<ArticleItemDto> articles;
+}

--- a/src/main/java/project/votebackend/dto/article/ClusterSummaryDto.java
+++ b/src/main/java/project/votebackend/dto/article/ClusterSummaryDto.java
@@ -1,0 +1,15 @@
+package project.votebackend.dto.article;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@AllArgsConstructor
+public class ClusterSummaryDto {
+    private Long id;
+    private String imageUrl;
+    private String title;
+    private LocalDateTime createdAt;
+}

--- a/src/main/java/project/votebackend/exception/ClusterException.java
+++ b/src/main/java/project/votebackend/exception/ClusterException.java
@@ -1,0 +1,23 @@
+package project.votebackend.exception;
+
+import lombok.*;
+import project.votebackend.type.ErrorCode;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class ClusterException extends RuntimeException {
+    private ErrorCode errorCode;
+    private String errorMessage;
+
+    public ClusterException(ErrorCode errorCode){
+        this.errorCode = errorCode;
+        this.errorMessage = errorCode.getDescription();
+    }
+
+    public int getHttpStatus() {
+        return errorCode.getHttpStatus().value();
+    }
+}

--- a/src/main/java/project/votebackend/exception/GlobalExceptionHandler.java
+++ b/src/main/java/project/votebackend/exception/GlobalExceptionHandler.java
@@ -62,6 +62,16 @@ public class GlobalExceptionHandler {
                 .body(new ErrorResponse(e.getErrorCode(), e.getErrorMessage()));
     }
 
+    // ClusterException 예외 처리 - 기사 관련 예외 발생 시 실행됨
+    @ExceptionHandler(FollowException.class)
+    public ResponseEntity<ErrorResponse> handleClusterException(ClusterException e) {
+        log.error("{}", e.getErrorCode());
+
+        return ResponseEntity
+                .status(e.getErrorCode().getHttpStatus())
+                .body(new ErrorResponse(e.getErrorCode(), e.getErrorMessage()));
+    }
+
     // 기타 모든 예외 처리 - 명시되지 않은 예외 발생 시 실행됨
     @ExceptionHandler(Exception.class)
     public ResponseEntity<ErrorResponse> handleException(Exception e) {

--- a/src/main/java/project/votebackend/service/article/ClusterService.java
+++ b/src/main/java/project/votebackend/service/article/ClusterService.java
@@ -1,0 +1,30 @@
+package project.votebackend.service.article;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import project.votebackend.domain.article.Cluster;
+import project.votebackend.dto.article.ClusterSummaryDto;
+import project.votebackend.repository.article.ClusterRepository;
+
+@Service
+@RequiredArgsConstructor
+public class ClusterService {
+
+    private final ClusterRepository clusterRepository;
+
+    public Page<ClusterSummaryDto> getMainPageClusters(Pageable pageable) {
+        return clusterRepository.findAll(pageable)
+                .map(this::toSummary);
+    }
+
+    private ClusterSummaryDto toSummary(Cluster c) {
+        return new ClusterSummaryDto(
+                c.getId(),
+                c.getTitle(),
+                c.getImageUrl(),
+                c.getCreatedAt()
+        );
+    }
+}

--- a/src/main/java/project/votebackend/service/article/ClusterService.java
+++ b/src/main/java/project/votebackend/service/article/ClusterService.java
@@ -4,9 +4,17 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
+import project.votebackend.domain.article.Article;
 import project.votebackend.domain.article.Cluster;
+import project.votebackend.dto.article.ArticleItemDto;
+import project.votebackend.dto.article.ClusterDetailDto;
 import project.votebackend.dto.article.ClusterSummaryDto;
+import project.votebackend.exception.ClusterException;
 import project.votebackend.repository.article.ClusterRepository;
+import project.votebackend.type.ErrorCode;
+
+import java.util.Comparator;
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -14,9 +22,45 @@ public class ClusterService {
 
     private final ClusterRepository clusterRepository;
 
+    // 뉴스 조회
     public Page<ClusterSummaryDto> getMainPageClusters(Pageable pageable) {
         return clusterRepository.findAll(pageable)
                 .map(this::toSummary);
+    }
+
+    // 뉴스 상세 조회
+    public ClusterDetailDto getClusterDetail(Long clusterId) {
+        Cluster c = clusterRepository.findById(clusterId)
+                .orElseThrow(() -> new ClusterException(ErrorCode.CLUSTER_NOT_FOUND));
+
+        // 최신순 정렬
+        List<ArticleItemDto> articles = c.getArticles().stream()
+                .sorted(Comparator.comparing(Article::getPublishedAt,
+                        Comparator.nullsLast(Comparator.naturalOrder())).reversed())
+                .map(a -> new ArticleItemDto(
+                        a.getUrl(),
+                        a.getOriginalUrl(),
+                        a.getTitle(),
+                        a.getPublisher(),
+                        a.getPublishedAt()
+                ))
+                .toList();
+
+        return new ClusterDetailDto(
+                c.getId(),
+                c.getImageUrl(),
+                c.getTitle(),
+                c.getCreatedAt(),
+                c.getSubtitle1(),
+                c.getSubtitle2(),
+                c.getSubtitle3(),
+                c.getSubtitle4(),
+                c.getContent1(),
+                c.getContent2(),
+                c.getContent3(),
+                c.getContent4(),
+                articles
+        );
     }
 
     private ClusterSummaryDto toSummary(Cluster c) {

--- a/src/main/java/project/votebackend/type/ErrorCode.java
+++ b/src/main/java/project/votebackend/type/ErrorCode.java
@@ -33,7 +33,11 @@ public enum ErrorCode {
     ALREADY_FOLLOW(HttpStatus.CONFLICT, "이미 팔로우 중입니다."),
 
     //Mail
-    CODE_NOT_MATCHED(HttpStatus.CONFLICT, "코드가 일치하지 않습니다.");
+    CODE_NOT_MATCHED(HttpStatus.CONFLICT, "코드가 일치하지 않습니다."),
+
+    //Cluster
+    CLUSTER_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 기사입니다.");
+
 
 
     private final HttpStatus httpStatus;


### PR DESCRIPTION
### 📌 관련 이슈
- [062-get-news]

### 🔍 작업 내용
1. ClusterService / ClusterController 수정
   - 메인 페이지 조회 API(`GET /cluster`) 구현
   - Cluster 엔티티 → `ClusterSummaryDto` 변환 후 페이징 반환
   - `PageResponseUtil` 활용하여 프론트와 동일한 응답 구조 유지

2. Cluster 상세 조회 API(`GET /cluster/{clusterId}`) 추가
   - `ClusterDetailDto`, `ArticleItemDto` 생성
   - 썸네일, 제목, 생성일자, subtitle(1~4), content(1~4) 포함
   - 관련 기사(`articles`) 목록 함께 반환 (url, originalUrl, title, publisher, publishedAt)