### PR TITLE
fix: [013-create-vote] 투표 생성시 이미지, 옵션 섞이는 문제 해결

### DIFF
--- a/src/main/java/project/votebackend/domain/vote/Vote.java
+++ b/src/main/java/project/votebackend/domain/vote/Vote.java
@@ -53,11 +53,13 @@ public class Vote extends BaseEntity {
 
     @OneToMany(mappedBy = "vote", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
     @BatchSize(size = 50)
-    private Set<VoteOption> options = new HashSet<>();
+    @OrderColumn(name = "order_index")
+    private List<VoteOption> options = new ArrayList<>();
 
     @OneToMany(mappedBy = "vote", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
     @BatchSize(size = 50)
-    private Set<VoteImage> images = new HashSet<>();
+    @OrderColumn(name = "order_index")
+    private List<VoteImage> images = new ArrayList<>();
 
     @OneToMany(mappedBy = "vote", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
     @BatchSize(size = 50)

--- a/src/main/java/project/votebackend/service/vote/AiVoteService.java
+++ b/src/main/java/project/votebackend/service/vote/AiVoteService.java
@@ -100,7 +100,7 @@ public class AiVoteService {
         vote.setCategory(category);
 
         // 옵션
-        if (vote.getOptions() == null) vote.setOptions(new HashSet<>());
+        if (vote.getOptions() == null) vote.setOptions(new ArrayList<>());
         for (VoteOptionDto od : optionDtos) {
             VoteOption o = new VoteOption();
             o.setVote(vote);
@@ -111,7 +111,7 @@ public class AiVoteService {
 
         // 이미지
         if (req.getImageUrls() != null && !req.getImageUrls().isEmpty()) {
-            if (vote.getImages() == null) vote.setImages(new HashSet<>());
+            if (vote.getImages() == null) vote.setImages(new ArrayList<>());
             req.getImageUrls().forEach(url -> {
                 VoteImage img = new VoteImage();
                 img.setVote(vote);

--- a/src/main/java/project/votebackend/service/vote/VoteService.java
+++ b/src/main/java/project/votebackend/service/vote/VoteService.java
@@ -73,24 +73,24 @@ public class VoteService {
 
 
         // 옵션 추가
-        Set<VoteOption> options = request.getOptions().stream().map(opt -> {
+        List<VoteOption> options = request.getOptions().stream().map(opt -> {
             VoteOption o = new VoteOption();
             o.setVote(vote);
             o.setOption(opt.getContent());
             o.setOptionImage(opt.getOptionImage());
             return o;
-        }).collect(Collectors.toSet());
+        }).collect(Collectors.toList());
 
         vote.setOptions(options);
 
         // 이미지 추가
         if (request.getImageUrls() != null) {
-            Set<VoteImage> images = request.getImageUrls().stream().map(url -> {
+            List<VoteImage> images = request.getImageUrls().stream().map(url -> {
                 VoteImage img = new VoteImage();
                 img.setVote(vote);
                 img.setImageUrl(url);
                 return img;
-            }).collect(Collectors.toSet());
+            }).collect(Collectors.toList());
             vote.setImages(images);
         }
 
@@ -130,24 +130,24 @@ public class VoteService {
 
 
         // 옵션 추가
-        Set<VoteOption> options = request.getOptions().stream().map(opt -> {
+        List<VoteOption> options = request.getOptions().stream().map(opt -> {
             VoteOption o = new VoteOption();
             o.setVote(vote);
             o.setOption(opt.getContent());
             o.setOptionImage(opt.getOptionImage());
             return o;
-        }).collect(Collectors.toSet());
+        }).collect(Collectors.toList());
 
         vote.setOptions(options);
 
         // 이미지 추가
         if (request.getImageUrls() != null) {
-            Set<VoteImage> images = request.getImageUrls().stream().map(url -> {
+            List<VoteImage> images = request.getImageUrls().stream().map(url -> {
                 VoteImage img = new VoteImage();
                 img.setVote(vote);
                 img.setImageUrl(url);
                 return img;
-            }).collect(Collectors.toSet());
+            }).collect(Collectors.toList());
             vote.setImages(images);
         }
 


### PR DESCRIPTION
### 📌 관련 이슈
- #196 

### 🔍 작업 내용
- `Set<VoteOption>`, `Set<VoteImage>` 
  → `List<VoteOption>` +` @OrderColumn("order_index")`, `List<VoteImage>` + `@OrderColumn("order_index")`
- 즉, 순서를 DB에 명시적으로 저장하고(order_index), 읽을 때도 그 순서로 복원되도록 수정.